### PR TITLE
Add Pub/Sub filter test and rename and unify test codes into "Test" s…

### DIFF
--- a/tests/MessagePipe.Tests/PubSubAsyncFilterTest.cs
+++ b/tests/MessagePipe.Tests/PubSubAsyncFilterTest.cs
@@ -1,0 +1,62 @@
+﻿using FluentAssertions;
+using MessagePipe;
+using MessagePipe.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Generic;
+using Xunit;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Threading;
+
+// for check diagnostics, modify namespace.
+namespace __MessagePipe.Tests
+{
+    public class PubSubAsyncFilterTest
+    {
+        [Fact]
+        public void SimplePushAsyncWithFilter()
+        {
+            var provider = TestHelper.BuildServiceProvider();
+
+            var info = provider.GetRequiredService<MessagePipeDiagnosticsInfo>();
+            var p = provider.GetRequiredService<IAsyncPublisher<string>>();
+            var s = provider.GetRequiredService<IAsyncSubscriber<string>>();
+
+            var result = new List<string>();
+#pragma warning disable CS1998
+            var d = s.Subscribe(async (x,ct) => result.Add("d:" + x));
+            var f = s.Subscribe(async (x, ct) => result.Add("f:" + x), new AsyncReverseFilter());
+            var ff = s.Subscribe(async (x, ct) => result.Add("f:" + x), new AsyncReverseFilter(), new AsyncReverseFilter());
+#pragma warning restore CS1998
+
+            info.SubscribeCount.Should().Be(3);
+
+            // use BeEquivalentTo, allow different order
+
+            p.Publish("one");
+            result.Should().BeEquivalentTo("d:one", "f:eno", "f:one");
+            result.Clear();
+
+            d.Dispose();
+
+            p.Publish("two");
+            result.Should().BeEquivalentTo("f:owt", "f:two");
+            result.Clear();
+            f.Dispose();
+
+            p.Publish("three");
+            result.Should().BeEquivalentTo("f:three");
+            result.Clear();
+            ff.Dispose();
+            info.SubscribeCount.Should().Be(0);
+        }
+    }
+    class AsyncReverseFilter : AsyncMessageHandlerFilter<string>
+    {
+        public override async ValueTask HandleAsync(string message, CancellationToken cancellationToken, System.Func<string, CancellationToken, ValueTask> next)
+        {
+            var filtered = string.Concat(message.Reverse());
+            await next(filtered, cancellationToken);
+        }
+    }
+}

--- a/tests/MessagePipe.Tests/PubSubFilterTest.cs
+++ b/tests/MessagePipe.Tests/PubSubFilterTest.cs
@@ -1,0 +1,80 @@
+﻿using FluentAssertions;
+using MessagePipe;
+using MessagePipe.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Generic;
+using Xunit;
+using System.Linq;
+
+// for check diagnostics, modify namespace.
+namespace __MessagePipe.Tests
+{
+    public class PubSubFilterTest
+    {
+        [Fact]
+        public void SimplePushWithFilter()
+        {
+            var provider = TestHelper.BuildServiceProvider();
+
+            var info = provider.GetRequiredService<MessagePipeDiagnosticsInfo>();
+            var p = provider.GetRequiredService<IPublisher<string>>();
+            var s = provider.GetRequiredService<ISubscriber<string>>();
+
+            var result = new List<string>();
+            var d = s.Subscribe(x => result.Add("d:" + x));
+            var f = s.Subscribe(x => result.Add("f:" + x),new ReverseFilter());
+            var ff = s.Subscribe(x => result.Add("f:" + x), new ReverseFilter(), new ReverseFilter());
+
+            info.SubscribeCount.Should().Be(3);
+
+            // use BeEquivalentTo, allow different order
+
+            p.Publish("one");
+            result.Should().BeEquivalentTo("d:one", "f:eno", "f:one");
+            result.Clear();
+
+            d.Dispose();
+
+            p.Publish("two");
+            result.Should().BeEquivalentTo("f:owt","f:two");
+            result.Clear();
+            f.Dispose();
+
+            p.Publish("three");
+            result.Should().BeEquivalentTo("f:three");
+            result.Clear();
+            ff.Dispose();
+            info.SubscribeCount.Should().Be(0);
+
+            var g = s.Subscribe(x => 
+            result.Add("g:" + x),new GenericFilter<string>());
+            p.Publish("four");
+            result.Should().BeEquivalentTo("g:four");
+            FilterResultContainer.MessageBefore.Should().Be("Before");
+            FilterResultContainer.MessageAfter.Should().Be("After");
+        }
+    }
+    class ReverseFilter : MessageHandlerFilter<string>
+    {
+        public override void Handle(string message, System.Action<string> next)
+        {
+            var filtered = string.Concat(message.Reverse());
+            next(filtered);
+        }
+    }
+    class GenericFilter<T> : MessageHandlerFilter<T>
+    {
+
+        public override void Handle(T message, System.Action<T> next)
+        {
+            FilterResultContainer.MessageBefore = "Before";
+            next(message);
+            FilterResultContainer.MessageAfter = "After";
+        }
+    }
+    static class FilterResultContainer
+    {
+        public static string MessageBefore;
+        public static string MessageAfter;
+    }
+}

--- a/tests/MessagePipe.Tests/PubSubKeyedSyncTest.cs
+++ b/tests/MessagePipe.Tests/PubSubKeyedSyncTest.cs
@@ -1,6 +1,4 @@
-﻿#pragma warning disable CS1998
-
-using FluentAssertions;
+﻿using FluentAssertions;
 using MessagePipe;
 using MessagePipe.Tests;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,7 +8,7 @@ using Xunit;
 // for check diagnostics, modify namespace.
 namespace __MessagePipe.Tests
 {
-    public class PubsubKeyedASync
+    public class PubSubKeyedSyncTest
     {
         [Fact]
         public void SimplePush()
@@ -21,13 +19,13 @@ namespace __MessagePipe.Tests
             var provider = TestHelper.BuildServiceProvider();
 
             var info = provider.GetRequiredService<MessagePipeDiagnosticsInfo>();
-            var p = provider.GetRequiredService<IAsyncPublisher<string, string>>();
-            var s = provider.GetRequiredService<IAsyncSubscriber<string, string>>();
+            var p = provider.GetRequiredService<IPublisher<string, string>>();
+            var s = provider.GetRequiredService<ISubscriber<string, string>>();
 
             var result = new List<string>();
-            var d1 = s.Subscribe(Key1, async (x, ct) => result.Add("1:" + x));
-            var d2 = s.Subscribe(Key2, async (x, ct) => result.Add("2:" + x));
-            var d3 = s.Subscribe(Key1, async (x, ct) => result.Add("3:" + x));
+            var d1 = s.Subscribe(Key1, x => result.Add("1:" + x));
+            var d2 = s.Subscribe(Key2, x => result.Add("2:" + x));
+            var d3 = s.Subscribe(Key1, x => result.Add("3:" + x));
 
             info.SubscribeCount.Should().Be(3);
 

--- a/tests/MessagePipe.Tests/PubSubKeylessAsyncTest.cs
+++ b/tests/MessagePipe.Tests/PubSubKeylessAsyncTest.cs
@@ -13,7 +13,7 @@ using Xunit;
 // for check diagnostics, modify namespace.
 namespace __MessagePipe.Tests
 {
-    public class PubsubKeylessAsync
+    public class PubsubKeylessAsyncTest
     {
         [Fact]
         public async Task SameAsSync()

--- a/tests/MessagePipe.Tests/PubsubKeyedAsyncTest.cs
+++ b/tests/MessagePipe.Tests/PubsubKeyedAsyncTest.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿#pragma warning disable CS1998
+
+using FluentAssertions;
 using MessagePipe;
 using MessagePipe.Tests;
 using Microsoft.Extensions.DependencyInjection;
@@ -8,7 +10,7 @@ using Xunit;
 // for check diagnostics, modify namespace.
 namespace __MessagePipe.Tests
 {
-    public class PubSubKeyedSync
+    public class PubsubKeyedAsyncTest
     {
         [Fact]
         public void SimplePush()
@@ -19,13 +21,13 @@ namespace __MessagePipe.Tests
             var provider = TestHelper.BuildServiceProvider();
 
             var info = provider.GetRequiredService<MessagePipeDiagnosticsInfo>();
-            var p = provider.GetRequiredService<IPublisher<string, string>>();
-            var s = provider.GetRequiredService<ISubscriber<string, string>>();
+            var p = provider.GetRequiredService<IAsyncPublisher<string, string>>();
+            var s = provider.GetRequiredService<IAsyncSubscriber<string, string>>();
 
             var result = new List<string>();
-            var d1 = s.Subscribe(Key1, x => result.Add("1:" + x));
-            var d2 = s.Subscribe(Key2, x => result.Add("2:" + x));
-            var d3 = s.Subscribe(Key1, x => result.Add("3:" + x));
+            var d1 = s.Subscribe(Key1, async (x, ct) => result.Add("1:" + x));
+            var d2 = s.Subscribe(Key2, async (x, ct) => result.Add("2:" + x));
+            var d3 = s.Subscribe(Key1, async (x, ct) => result.Add("3:" + x));
 
             info.SubscribeCount.Should().Be(3);
 

--- a/tests/MessagePipe.Tests/PubsubKeylessSyncTest.cs
+++ b/tests/MessagePipe.Tests/PubsubKeylessSyncTest.cs
@@ -8,7 +8,7 @@ using Xunit;
 // for check diagnostics, modify namespace.
 namespace __MessagePipe.Tests
 {
-    public class PubsubKeylessSync
+    public class PubsubKeylessSyncTest
     {
         [Fact]
         public void SimplePush()


### PR DESCRIPTION
I've added test codes for checking Pub/Sub Filters which I think have lacked from this repository.
All of the additional tests have passed.
And I also renamed test codes and unify into a suffix "*Test.cs", regarding consistency.
Please merge if no problem.