### PR TITLE
Add `[Preserve]` to AsyncRequestHandler

### DIFF
--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe/Runtime/AsyncRequestHandler.cs
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe/Runtime/AsyncRequestHandler.cs
@@ -10,10 +10,12 @@ namespace MessagePipe
 {
     // async
 
+    [Preserve]
     public sealed class AsyncRequestHandler<TRequest, TResponse> : IAsyncRequestHandler<TRequest, TResponse>
     {
         readonly IAsyncRequestHandlerCore<TRequest, TResponse> handler;
 
+        [Preserve]
         public AsyncRequestHandler(IAsyncRequestHandlerCore<TRequest, TResponse> handler, FilterAttachedAsyncRequestHandlerFactory handlerFactory)
         {
             this.handler = handlerFactory.CreateAsyncRequestHandler<TRequest, TResponse>(handler);
@@ -25,11 +27,13 @@ namespace MessagePipe
         }
     }
 
+    [Preserve]
     public sealed class AsyncRequestAllHandler<TRequest, TResponse> : IAsyncRequestAllHandler<TRequest, TResponse>
     {
         readonly IAsyncRequestHandlerCore<TRequest, TResponse>[] handlers;
         readonly AsyncPublishStrategy defaultAsyncPublishStrategy;
 
+        [Preserve]
         public AsyncRequestAllHandler(IEnumerable<IAsyncRequestHandlerCore<TRequest, TResponse>> handlers, FilterAttachedAsyncRequestHandlerFactory handlerFactory, MessagePipeOptions options)
         {
             var collection = (handlers as ICollection<IAsyncRequestHandlerCore<TRequest, TResponse>>) ?? handlers.ToArray();

--- a/src/MessagePipe/AsyncRequestHandler.cs
+++ b/src/MessagePipe/AsyncRequestHandler.cs
@@ -10,10 +10,12 @@ namespace MessagePipe
 {
     // async
 
+    [Preserve]
     public sealed class AsyncRequestHandler<TRequest, TResponse> : IAsyncRequestHandler<TRequest, TResponse>
     {
         readonly IAsyncRequestHandlerCore<TRequest, TResponse> handler;
 
+        [Preserve]
         public AsyncRequestHandler(IAsyncRequestHandlerCore<TRequest, TResponse> handler, FilterAttachedAsyncRequestHandlerFactory handlerFactory)
         {
             this.handler = handlerFactory.CreateAsyncRequestHandler<TRequest, TResponse>(handler);
@@ -25,11 +27,13 @@ namespace MessagePipe
         }
     }
 
+    [Preserve]
     public sealed class AsyncRequestAllHandler<TRequest, TResponse> : IAsyncRequestAllHandler<TRequest, TResponse>
     {
         readonly IAsyncRequestHandlerCore<TRequest, TResponse>[] handlers;
         readonly AsyncPublishStrategy defaultAsyncPublishStrategy;
 
+        [Preserve]
         public AsyncRequestAllHandler(IEnumerable<IAsyncRequestHandlerCore<TRequest, TResponse>> handlers, FilterAttachedAsyncRequestHandlerFactory handlerFactory, MessagePipeOptions options)
         {
             var collection = (handlers as ICollection<IAsyncRequestHandlerCore<TRequest, TResponse>>) ?? handlers.ToArray();


### PR DESCRIPTION
Hello. I have encountered a problem with the IL2CPP strip in `RegisterAsyncRequestHandler` of VContainer.
https://github.com/hadashiA/VContainer/issues/253

As far as I can see, `RequestHandler<,>` has `[Preserve]`, but `AsyncRequestHandler<,>` doesn't seem to have it.

I tried to add `[Preserve]`, and it seems to work.
