### PR TITLE
Add "ZenjectScope" and the argument to be able to specify Zenject scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1118,7 +1118,7 @@ void Configure(DiContainer builder)
     var options = builder.BindMessagePipe(/* configure option */);
     
     // BindMessageBroker: Register for IPublisher<T>/ISubscriber<T>, includes async and buffered.
-    builder.BindMessageBroker<int>(options);
+    builder.BindMessageBroker<int>(options, ZenjectScope.Single);
 
     // also exists BindMessageBroker<TKey, TMessage>, BindRequestHandler, BindAsyncRequestHandler
 
@@ -1130,7 +1130,7 @@ void Configure(DiContainer builder)
 }
 ```
 
-> Zenject version is not supported `InstanceScope.Singleton` for Zenject's limitation. The default is `Scoped`, which cannot be changed.
+> Zenject version is requried to specify a Zenject scope to binding methods. `InstanceLifetime` and `RequestHandlerLifetime` will be ignored.
 
 `BuiltinContainerBuilder` is builtin minimum DI library for MessagePipe, it no needs other DI library to use MessagePipe. Here is installation sample.
 

--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Zenject/Runtime/DiContainerExtensions.cs
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Zenject/Runtime/DiContainerExtensions.cs
@@ -34,24 +34,20 @@ namespace MessagePipe
             var services = new DiContainerProxy(builder);
 
             // keyless PubSub
-            services.Add(typeof(MessageBrokerCore<TMessage>), scope);
-            services.Add(typeof(IPublisher<TMessage>), typeof(MessageBroker<TMessage>), scope);
-            services.Add(typeof(ISubscriber<TMessage>), typeof(MessageBroker<TMessage>), scope);
+            services.Add<MessageBrokerCore<TMessage>>(scope);
+            services.Add<IPublisher<TMessage>, ISubscriber<TMessage>, MessageBroker<TMessage>>(scope);
 
             // keyless PubSub async
-            services.Add(typeof(AsyncMessageBrokerCore<TMessage>), scope);
-            services.Add(typeof(IAsyncPublisher<TMessage>), typeof(AsyncMessageBroker<TMessage>), scope);
-            services.Add(typeof(IAsyncSubscriber<TMessage>), typeof(AsyncMessageBroker<TMessage>), scope);
+            services.Add<AsyncMessageBrokerCore<TMessage>>(scope);
+            services.Add<IAsyncPublisher<TMessage>, IAsyncSubscriber<TMessage>, AsyncMessageBroker<TMessage>>(scope);
 
             // keyless buffered PubSub
-            services.Add(typeof(BufferedMessageBrokerCore<TMessage>), scope);
-            services.Add(typeof(IBufferedPublisher<TMessage>), typeof(BufferedMessageBroker<TMessage>), scope);
-            services.Add(typeof(IBufferedSubscriber<TMessage>), typeof(BufferedMessageBroker<TMessage>), scope);
+            services.Add<BufferedMessageBrokerCore<TMessage>>(scope);
+            services.Add<IBufferedPublisher<TMessage>, IBufferedSubscriber<TMessage>, BufferedMessageBroker<TMessage>>(scope);
 
             // keyless buffered PubSub async
-            services.Add(typeof(BufferedAsyncMessageBrokerCore<TMessage>), scope);
-            services.Add(typeof(IBufferedAsyncPublisher<TMessage>), typeof(BufferedAsyncMessageBroker<TMessage>), scope);
-            services.Add(typeof(IBufferedAsyncSubscriber<TMessage>), typeof(BufferedAsyncMessageBroker<TMessage>), scope);
+            services.Add<BufferedAsyncMessageBrokerCore<TMessage>>(scope);
+            services.Add<IBufferedAsyncPublisher<TMessage>, IBufferedAsyncSubscriber<TMessage>, BufferedAsyncMessageBroker<TMessage>>(scope);
 
             return builder;
         }
@@ -62,44 +58,42 @@ namespace MessagePipe
             var services = new DiContainerProxy(builder);
 
             // keyed PubSub
-            services.Add(typeof(MessageBrokerCore<TKey, TMessage>), scope);
-            services.Add(typeof(IPublisher<TKey, TMessage>), typeof(MessageBroker<TKey, TMessage>), scope);
-            services.Add(typeof(ISubscriber<TKey, TMessage>), typeof(MessageBroker<TKey, TMessage>), scope);
+            services.Add<MessageBrokerCore<TKey, TMessage>>(scope);
+            services.Add<IPublisher<TKey, TMessage>, ISubscriber<TKey, TMessage>, MessageBroker<TKey, TMessage>>(scope);
 
             // keyed PubSub async
-            services.Add(typeof(AsyncMessageBrokerCore<TKey, TMessage>), scope);
-            services.Add(typeof(IAsyncPublisher<TKey, TMessage>), typeof(AsyncMessageBroker<TKey, TMessage>), scope);
-            services.Add(typeof(IAsyncSubscriber<TKey, TMessage>), typeof(AsyncMessageBroker<TKey, TMessage>), scope);
+            services.Add<AsyncMessageBrokerCore<TKey, TMessage>>(scope);
+            services.Add<IAsyncPublisher<TKey, TMessage>, IAsyncSubscriber<TKey, TMessage>, AsyncMessageBroker<TKey, TMessage>>(scope);
 
             return builder;
         }
 
         /// <summary>Register IRequestHandler[TRequest, TResponse](includes All) to container builder.</summary>
         public static DiContainer BindRequestHandler<TRequest, TResponse, THandler>(this DiContainer builder, MessagePipeOptions options, ZenjectScope scope = ZenjectScope.Single)
-            where THandler : IRequestHandler
+            where THandler : IRequestHandlerCore<TRequest, TResponse>
         {
             var services = new DiContainerProxy(builder);
 
-            services.Add(typeof(IRequestHandlerCore<TRequest, TResponse>), typeof(THandler), scope);
+            services.Add<IRequestHandlerCore<TRequest, TResponse>, THandler>(scope);
             if (!builder.HasBinding<IRequestHandler<TRequest, TResponse>>())
             {
-                services.Add(typeof(IRequestHandler<TRequest, TResponse>), typeof(RequestHandler<TRequest, TResponse>), scope);
-                services.Add(typeof(IRequestAllHandler<TRequest, TResponse>), typeof(RequestAllHandler<TRequest, TResponse>), scope);
+                services.Add<IRequestHandler<TRequest, TResponse>, RequestHandler<TRequest, TResponse>>(scope);
+                services.Add<IRequestAllHandler<TRequest, TResponse>, RequestAllHandler<TRequest, TResponse>>(scope);
             }
             return builder;
         }
 
         /// <summary>Register IAsyncRequestHandler[TRequest, TResponse](includes All) to container builder.</summary>
         public static DiContainer BindAsyncRequestHandler<TRequest, TResponse, THandler>(this DiContainer builder, MessagePipeOptions options, ZenjectScope scope = ZenjectScope.Single)
-            where THandler : IAsyncRequestHandler
+            where THandler : IAsyncRequestHandlerCore<TRequest, TResponse>
         {
             var services = new DiContainerProxy(builder);
 
-            services.Add(typeof(IAsyncRequestHandlerCore<TRequest, TResponse>), typeof(THandler), scope);
+            services.Add<IAsyncRequestHandlerCore<TRequest, TResponse>, THandler>(scope);
             if (!builder.HasBinding<IAsyncRequestHandler<TRequest, TResponse>>())
             {
-                services.Add(typeof(IAsyncRequestHandler<TRequest, TResponse>), typeof(AsyncRequestHandler<TRequest, TResponse>), scope);
-                services.Add(typeof(IAsyncRequestAllHandler<TRequest, TResponse>), typeof(AsyncRequestAllHandler<TRequest, TResponse>), scope);
+                services.Add<IAsyncRequestHandler<TRequest, TResponse>, AsyncRequestHandler<TRequest, TResponse>>(scope);
+                services.Add<IAsyncRequestAllHandler<TRequest, TResponse>, AsyncRequestAllHandler<TRequest, TResponse>>(scope);
             }
             return builder;
         }

--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Zenject/Runtime/DiContainerExtensions.cs
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Zenject/Runtime/DiContainerExtensions.cs
@@ -21,16 +21,6 @@ namespace MessagePipe
             {
                 configure(x);
                 options = x;
-
-                // Zenject 6 does not allow regsiter multiple singleton, it causes annoying error.
-                // https://github.com/modesttree/Zenject#upgrade-guide-for-zenject-6
-                // so force use Scoped.
-                options.InstanceLifetime = (options.InstanceLifetime == InstanceLifetime.Singleton)
-                    ? InstanceLifetime.Scoped
-                    : options.RequestHandlerLifetime;
-                options.RequestHandlerLifetime = (options.RequestHandlerLifetime == InstanceLifetime.Singleton)
-                    ? InstanceLifetime.Scoped
-                    : options.RequestHandlerLifetime;
             });
 
             builder.Bind<IServiceProvider>().To<DiContainerProviderProxy>().AsCached();
@@ -39,81 +29,77 @@ namespace MessagePipe
         }
 
         /// <summary>Register IPublisher[TMessage] and ISubscriber[TMessage](includes Async/Buffered) to container builder.</summary>
-        public static DiContainer BindMessageBroker<TMessage>(this DiContainer builder, MessagePipeOptions options)
+        public static DiContainer BindMessageBroker<TMessage>(this DiContainer builder, MessagePipeOptions options, ZenjectScope scope = ZenjectScope.Single)
         {
-            var lifetime = options.InstanceLifetime;
             var services = new DiContainerProxy(builder);
 
             // keyless PubSub
-            services.Add(typeof(MessageBrokerCore<TMessage>), lifetime);
-            services.Add(typeof(IPublisher<TMessage>), typeof(MessageBroker<TMessage>), lifetime);
-            services.Add(typeof(ISubscriber<TMessage>), typeof(MessageBroker<TMessage>), lifetime);
+            services.Add(typeof(MessageBrokerCore<TMessage>), scope);
+            services.Add(typeof(IPublisher<TMessage>), typeof(MessageBroker<TMessage>), scope);
+            services.Add(typeof(ISubscriber<TMessage>), typeof(MessageBroker<TMessage>), scope);
 
             // keyless PubSub async
-            services.Add(typeof(AsyncMessageBrokerCore<TMessage>), lifetime);
-            services.Add(typeof(IAsyncPublisher<TMessage>), typeof(AsyncMessageBroker<TMessage>), lifetime);
-            services.Add(typeof(IAsyncSubscriber<TMessage>), typeof(AsyncMessageBroker<TMessage>), lifetime);
+            services.Add(typeof(AsyncMessageBrokerCore<TMessage>), scope);
+            services.Add(typeof(IAsyncPublisher<TMessage>), typeof(AsyncMessageBroker<TMessage>), scope);
+            services.Add(typeof(IAsyncSubscriber<TMessage>), typeof(AsyncMessageBroker<TMessage>), scope);
 
             // keyless buffered PubSub
-            services.Add(typeof(BufferedMessageBrokerCore<TMessage>), lifetime);
-            services.Add(typeof(IBufferedPublisher<TMessage>), typeof(BufferedMessageBroker<TMessage>), lifetime);
-            services.Add(typeof(IBufferedSubscriber<TMessage>), typeof(BufferedMessageBroker<TMessage>), lifetime);
+            services.Add(typeof(BufferedMessageBrokerCore<TMessage>), scope);
+            services.Add(typeof(IBufferedPublisher<TMessage>), typeof(BufferedMessageBroker<TMessage>), scope);
+            services.Add(typeof(IBufferedSubscriber<TMessage>), typeof(BufferedMessageBroker<TMessage>), scope);
 
             // keyless buffered PubSub async
-            services.Add(typeof(BufferedAsyncMessageBrokerCore<TMessage>), lifetime);
-            services.Add(typeof(IBufferedAsyncPublisher<TMessage>), typeof(BufferedAsyncMessageBroker<TMessage>), lifetime);
-            services.Add(typeof(IBufferedAsyncSubscriber<TMessage>), typeof(BufferedAsyncMessageBroker<TMessage>), lifetime);
+            services.Add(typeof(BufferedAsyncMessageBrokerCore<TMessage>), scope);
+            services.Add(typeof(IBufferedAsyncPublisher<TMessage>), typeof(BufferedAsyncMessageBroker<TMessage>), scope);
+            services.Add(typeof(IBufferedAsyncSubscriber<TMessage>), typeof(BufferedAsyncMessageBroker<TMessage>), scope);
 
             return builder;
         }
 
         /// <summary>Register IPublisher[TKey, TMessage] and ISubscriber[TKey, TMessage](includes Async) to container builder.</summary>
-        public static DiContainer BindMessageBroker<TKey, TMessage>(this DiContainer builder, MessagePipeOptions options)
+        public static DiContainer BindMessageBroker<TKey, TMessage>(this DiContainer builder, MessagePipeOptions options, ZenjectScope scope = ZenjectScope.Single)
         {
-            var lifetime = options.InstanceLifetime;
             var services = new DiContainerProxy(builder);
 
             // keyed PubSub
-            services.Add(typeof(MessageBrokerCore<TKey, TMessage>), lifetime);
-            services.Add(typeof(IPublisher<TKey, TMessage>), typeof(MessageBroker<TKey, TMessage>), lifetime);
-            services.Add(typeof(ISubscriber<TKey, TMessage>), typeof(MessageBroker<TKey, TMessage>), lifetime);
+            services.Add(typeof(MessageBrokerCore<TKey, TMessage>), scope);
+            services.Add(typeof(IPublisher<TKey, TMessage>), typeof(MessageBroker<TKey, TMessage>), scope);
+            services.Add(typeof(ISubscriber<TKey, TMessage>), typeof(MessageBroker<TKey, TMessage>), scope);
 
             // keyed PubSub async
-            services.Add(typeof(AsyncMessageBrokerCore<TKey, TMessage>), lifetime);
-            services.Add(typeof(IAsyncPublisher<TKey, TMessage>), typeof(AsyncMessageBroker<TKey, TMessage>), lifetime);
-            services.Add(typeof(IAsyncSubscriber<TKey, TMessage>), typeof(AsyncMessageBroker<TKey, TMessage>), lifetime);
+            services.Add(typeof(AsyncMessageBrokerCore<TKey, TMessage>), scope);
+            services.Add(typeof(IAsyncPublisher<TKey, TMessage>), typeof(AsyncMessageBroker<TKey, TMessage>), scope);
+            services.Add(typeof(IAsyncSubscriber<TKey, TMessage>), typeof(AsyncMessageBroker<TKey, TMessage>), scope);
 
             return builder;
         }
 
         /// <summary>Register IRequestHandler[TRequest, TResponse](includes All) to container builder.</summary>
-        public static DiContainer BindRequestHandler<TRequest, TResponse, THandler>(this DiContainer builder, MessagePipeOptions options)
+        public static DiContainer BindRequestHandler<TRequest, TResponse, THandler>(this DiContainer builder, MessagePipeOptions options, ZenjectScope scope = ZenjectScope.Single)
             where THandler : IRequestHandler
         {
-            var lifetime = options.RequestHandlerLifetime;
             var services = new DiContainerProxy(builder);
 
-            services.Add(typeof(IRequestHandlerCore<TRequest, TResponse>), typeof(THandler), lifetime);
+            services.Add(typeof(IRequestHandlerCore<TRequest, TResponse>), typeof(THandler), scope);
             if (!builder.HasBinding<IRequestHandler<TRequest, TResponse>>())
             {
-                services.Add(typeof(IRequestHandler<TRequest, TResponse>), typeof(RequestHandler<TRequest, TResponse>), lifetime);
-                services.Add(typeof(IRequestAllHandler<TRequest, TResponse>), typeof(RequestAllHandler<TRequest, TResponse>), lifetime);
+                services.Add(typeof(IRequestHandler<TRequest, TResponse>), typeof(RequestHandler<TRequest, TResponse>), scope);
+                services.Add(typeof(IRequestAllHandler<TRequest, TResponse>), typeof(RequestAllHandler<TRequest, TResponse>), scope);
             }
             return builder;
         }
 
         /// <summary>Register IAsyncRequestHandler[TRequest, TResponse](includes All) to container builder.</summary>
-        public static DiContainer BindAsyncRequestHandler<TRequest, TResponse, THandler>(this DiContainer builder, MessagePipeOptions options)
+        public static DiContainer BindAsyncRequestHandler<TRequest, TResponse, THandler>(this DiContainer builder, MessagePipeOptions options, ZenjectScope scope = ZenjectScope.Single)
             where THandler : IAsyncRequestHandler
         {
-            var lifetime = options.RequestHandlerLifetime;
             var services = new DiContainerProxy(builder);
 
-            services.Add(typeof(IAsyncRequestHandlerCore<TRequest, TResponse>), typeof(THandler), lifetime);
+            services.Add(typeof(IAsyncRequestHandlerCore<TRequest, TResponse>), typeof(THandler), scope);
             if (!builder.HasBinding<IAsyncRequestHandler<TRequest, TResponse>>())
             {
-                services.Add(typeof(IAsyncRequestHandler<TRequest, TResponse>), typeof(AsyncRequestHandler<TRequest, TResponse>), lifetime);
-                services.Add(typeof(IAsyncRequestAllHandler<TRequest, TResponse>), typeof(AsyncRequestAllHandler<TRequest, TResponse>), lifetime);
+                services.Add(typeof(IAsyncRequestHandler<TRequest, TResponse>), typeof(AsyncRequestHandler<TRequest, TResponse>), scope);
+                services.Add(typeof(IAsyncRequestAllHandler<TRequest, TResponse>), typeof(AsyncRequestAllHandler<TRequest, TResponse>), scope);
             }
             return builder;
         }

--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Zenject/Runtime/TypeProxy.cs
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Zenject/Runtime/TypeProxy.cs
@@ -37,15 +37,23 @@ namespace MessagePipe.Zenject
             builder.Bind(type).AsSingle();
         }
 
-        public void Add(Type type, ZenjectScope scope)
+        public void Add<T>(ZenjectScope scope)
         {
-            var binder = builder.Bind(type);
+            var binder = builder.Bind<T>();
             SetScope(binder, scope);
         }
 
-        public void Add(Type serviceType, Type implementationType, ZenjectScope scope)
+        public void Add<TService, TImplementation>(ZenjectScope scope)
+            where TImplementation : TService
         {
-            var binder = builder.Bind(serviceType).To(implementationType);
+            var binder = builder.Bind<TService>().To<TImplementation>();
+            SetScope(binder, scope);
+        }
+
+        public void Add<TService1, TService2, TImplementation>(ZenjectScope scope)
+            where TImplementation : TService1, TService2
+        {
+            var binder = builder.Bind(typeof(TService1), typeof(TService2)).To<TImplementation>();
             SetScope(binder, scope);
         }
 

--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Zenject/Runtime/TypeProxy.cs
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Zenject/Runtime/TypeProxy.cs
@@ -37,27 +37,31 @@ namespace MessagePipe.Zenject
             builder.Bind(type).AsSingle();
         }
 
-        public void Add(Type type, InstanceLifetime lifetime)
+        public void Add(Type type, ZenjectScope scope)
         {
-            if (lifetime == InstanceLifetime.Scoped)
-            {
-                builder.Bind(type).AsCached();
-            }
-            else
-            {
-                builder.Bind(type).AsSingle();
-            }
+            var binder = builder.Bind(type);
+            SetScope(binder, scope);
         }
 
-        public void Add(Type serviceType, Type implementationType, InstanceLifetime lifetime)
+        public void Add(Type serviceType, Type implementationType, ZenjectScope scope)
         {
-            if (lifetime == InstanceLifetime.Scoped)
+            var binder = builder.Bind(serviceType).To(implementationType);
+            SetScope(binder, scope);
+        }
+
+        private void SetScope(ScopeConcreteIdArgConditionCopyNonLazyBinder binder, ZenjectScope scope)
+        {
+            if (scope == ZenjectScope.Cached)
             {
-                builder.Bind(serviceType).To(implementationType).AsCached();
+                binder.AsCached();
+            }
+            else if (scope == ZenjectScope.Single)
+            {
+                binder.AsSingle();
             }
             else
             {
-                builder.Bind(serviceType).To(implementationType).AsSingle();
+                binder.AsTransient();
             }
         }
     }

--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Zenject/Runtime/ZenjectScope.cs
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Zenject/Runtime/ZenjectScope.cs
@@ -1,0 +1,7 @@
+namespace MessagePipe
+{
+    public enum ZenjectScope
+    {
+        Single, Cached, Transient
+    }
+}

--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Zenject/Runtime/ZenjectScope.cs.meta
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Zenject/Runtime/ZenjectScope.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9916e0cd41cf1444bb8445bdabb36c11
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePipe.Unity/Assets/Tests/ZenjectTest.cs
+++ b/src/MessagePipe.Unity/Assets/Tests/ZenjectTest.cs
@@ -18,7 +18,7 @@ public class ZenjectTest
     {
         var resolver = TestHelper.BuildZenject((options, builder) =>
         {
-            builder.BindMessageBroker<int>(options);
+            builder.BindMessageBroker<int>(options, ZenjectScope.Single);
         });
 
         var pub = resolver.Resolve<IPublisher<int>>();
@@ -46,7 +46,7 @@ public class ZenjectTest
     {
         var resolver = TestHelper.BuildZenject((options, builder) =>
         {
-            builder.BindMessageBroker<int>(options);
+            builder.BindMessageBroker<int>(options, ZenjectScope.Single);
         });
 
         var pub = resolver.Resolve<IAsyncPublisher<int>>();
@@ -79,7 +79,7 @@ public class ZenjectTest
            options.AddGlobalMessageHandlerFilter<MyFilter<int>>(1200);
        }, (options, builder) =>
        {
-           builder.BindMessageBroker<int>(options);
+           builder.BindMessageBroker<int>(options, ZenjectScope.Single);
            builder.BindMessageHandlerFilter<MyFilter<int>>();
            builder.BindInstance(store);
        });
@@ -112,7 +112,7 @@ public class ZenjectTest
        }, (options, builder) =>
        {
            builder.BindInstance(store);
-           builder.BindRequestHandler<int, int, MyRequestHandler>(options);
+           builder.BindRequestHandler<int, int, MyRequestHandler>(options, ZenjectScope.Single);
        });
 
         var handler = resolver.Resolve<IRequestHandler<int, int>>();
@@ -136,13 +136,13 @@ public class ZenjectTest
 
         var resolver = TestHelper.BuildZenject(options =>
        {
-            // options.InstanceLifetime = InstanceLifetime.Scoped;
-            options.AddGlobalRequestHandlerFilter<MyRequestHandlerFilter>(-1799);
+           // options.InstanceLifetime = InstanceLifetime.Scoped;
+           options.AddGlobalRequestHandlerFilter<MyRequestHandlerFilter>(-1799);
        }, (options, builder) =>
        {
            builder.BindInstance(store);
-           builder.BindRequestHandler<int, int, MyRequestHandler>(options);
-           builder.BindRequestHandler<int, int, MyRequestHandler2>(options);
+           builder.BindRequestHandler<int, int, MyRequestHandler>(options, ZenjectScope.Single);
+           builder.BindRequestHandler<int, int, MyRequestHandler2>(options, ZenjectScope.Single);
        });
 
         var handler = resolver.Resolve<IRequestAllHandler<int, int>>();
@@ -166,7 +166,7 @@ public class ZenjectTest
     {
         var provider = TestHelper.BuildZenject((options, builder) =>
         {
-            builder.BindMessageBroker<IntClass>(options);
+            builder.BindMessageBroker<IntClass>(options, ZenjectScope.Single);
         });
 
         var p = provider.Resolve<IBufferedPublisher<IntClass>>();

--- a/src/MessagePipe.Unity/Assets/Tests/ZenjectTest.cs
+++ b/src/MessagePipe.Unity/Assets/Tests/ZenjectTest.cs
@@ -18,7 +18,7 @@ public class ZenjectTest
     {
         var resolver = TestHelper.BuildZenject((options, builder) =>
         {
-            builder.BindMessageBroker<int>(options, ZenjectScope.Single);
+            builder.BindMessageBroker<int>(options);
         });
 
         var pub = resolver.Resolve<IPublisher<int>>();
@@ -46,7 +46,7 @@ public class ZenjectTest
     {
         var resolver = TestHelper.BuildZenject((options, builder) =>
         {
-            builder.BindMessageBroker<int>(options, ZenjectScope.Single);
+            builder.BindMessageBroker<int>(options);
         });
 
         var pub = resolver.Resolve<IAsyncPublisher<int>>();
@@ -79,7 +79,7 @@ public class ZenjectTest
            options.AddGlobalMessageHandlerFilter<MyFilter<int>>(1200);
        }, (options, builder) =>
        {
-           builder.BindMessageBroker<int>(options, ZenjectScope.Single);
+           builder.BindMessageBroker<int>(options);
            builder.BindMessageHandlerFilter<MyFilter<int>>();
            builder.BindInstance(store);
        });
@@ -112,7 +112,7 @@ public class ZenjectTest
        }, (options, builder) =>
        {
            builder.BindInstance(store);
-           builder.BindRequestHandler<int, int, MyRequestHandler>(options, ZenjectScope.Single);
+           builder.BindRequestHandler<int, int, MyRequestHandler>(options);
        });
 
         var handler = resolver.Resolve<IRequestHandler<int, int>>();
@@ -141,8 +141,8 @@ public class ZenjectTest
        }, (options, builder) =>
        {
            builder.BindInstance(store);
-           builder.BindRequestHandler<int, int, MyRequestHandler>(options, ZenjectScope.Single);
-           builder.BindRequestHandler<int, int, MyRequestHandler2>(options, ZenjectScope.Single);
+           builder.BindRequestHandler<int, int, MyRequestHandler>(options);
+           builder.BindRequestHandler<int, int, MyRequestHandler2>(options);
        });
 
         var handler = resolver.Resolve<IRequestAllHandler<int, int>>();
@@ -166,7 +166,7 @@ public class ZenjectTest
     {
         var provider = TestHelper.BuildZenject((options, builder) =>
         {
-            builder.BindMessageBroker<IntClass>(options, ZenjectScope.Single);
+            builder.BindMessageBroker<IntClass>(options);
         });
 
         var p = provider.Resolve<IBufferedPublisher<IntClass>>();
@@ -193,6 +193,99 @@ public class ZenjectTest
         d3.Dispose();
         p.Publish(new IntClass { Value = 4 });
         CollectionAssert.AreEqual(new[] { 9999, 333, 333, 11, 11, 4 }, l);
+    }
+
+    [Test]
+    public void BindMessageBrokerWithScopeSingle()
+    {
+        var resolver = TestHelper.BuildZenject((options, builder) =>
+        {
+            builder.BindMessageBroker<int>(options, ZenjectScope.Single);
+        });
+
+        var pub1 = resolver.Resolve<IPublisher<int>>();
+        var pub2 = resolver.Resolve<IPublisher<int>>();
+        var sub1 = resolver.Resolve<ISubscriber<int>>();
+        var sub2 = resolver.Resolve<ISubscriber<int>>();
+
+        Assert.AreEqual(pub1, pub2);
+        Assert.AreEqual(pub1, sub1);
+        Assert.AreEqual(pub1, sub2);
+    }
+
+    [Test]
+    public void BindMessageBrokerWithScopeCached()
+    {
+        var resolver = TestHelper.BuildZenject((options, builder) =>
+        {
+            builder.BindMessageBroker<int>(options, ZenjectScope.Cached);
+        });
+
+        var pub1 = resolver.Resolve<IPublisher<int>>();
+        var pub2 = resolver.Resolve<IPublisher<int>>();
+        var sub1 = resolver.Resolve<ISubscriber<int>>();
+        var sub2 = resolver.Resolve<ISubscriber<int>>();
+
+        Assert.AreEqual(pub1, pub2);
+        Assert.AreEqual(pub1, sub1);
+        Assert.AreEqual(pub1, sub2);
+    }
+
+    [Test]
+    public void BindMessageBrokerWithScopeTransient()
+    {
+        var resolver = TestHelper.BuildZenject((options, builder) =>
+        {
+            builder.BindMessageBroker<int>(options, ZenjectScope.Transient);
+        });
+
+        var pub1 = resolver.Resolve<IPublisher<int>>();
+        var pub2 = resolver.Resolve<IPublisher<int>>();
+        var sub1 = resolver.Resolve<ISubscriber<int>>();
+        var sub2 = resolver.Resolve<ISubscriber<int>>();
+
+        Assert.AreNotEqual(pub1, pub2);
+        Assert.AreNotEqual(pub1, sub1);
+        Assert.AreNotEqual(pub1, sub2);
+    }
+
+    [Test]
+    public void BindMessageBrokerDuplicateBindWithScopeSingleThrowsException()
+    {
+        Assert.Throws<ZenjectException>(() =>
+        {
+            var resolver = TestHelper.BuildZenject((options, builder) =>
+            {
+                builder.BindMessageBroker<int>(options, ZenjectScope.Single);
+                builder.BindMessageBroker<int>(options, ZenjectScope.Single);
+            });
+        });
+    }
+
+    [Test]
+    public void BindMessageBrokerDuplicateBindWithScopeCachedDoesNotThrowsException()
+    {
+        Assert.DoesNotThrow(() =>
+        {
+            var sWAresolver = TestHelper.BuildZenject((options, builder) =>
+            {
+                builder.BindMessageBroker<int>(options, ZenjectScope.Cached);
+                builder.BindMessageBroker<int>(options, ZenjectScope.Cached);
+            });
+        });
+    }
+
+    [Test]
+    public void BindMessageBrokerDuplicateBindWithScopeTransientDoesNotThrowsException()
+    {
+        Assert.DoesNotThrow(() =>
+        {
+            var resolver = TestHelper.BuildZenject((options, builder) =>
+            {
+                builder.BindMessageBroker<int>(options, ZenjectScope.Transient);
+                builder.BindMessageBroker<int>(options, ZenjectScope.Transient);
+            });
+        });
     }
 
     public class IntClass


### PR DESCRIPTION
This PullRequest is destructive to Zenject features, so I will send this PR as a suggestion.

# Changes
- Add enum "ZenjectScope" to specify Zenject scopes when bindings
- Fix bindings for Zenject to be able to use Zenject "Single" (not Lifetime "Singleton")
  - Replace "InstanceLifetime" with "ZenjectScope" for Zenject bindings (The reason is described later)
- Add some tests for ZenjectScope to ZenjectTest

# Why Zenject scopes should be used
- Zenject scopes are not "Lifetime of certain Dependency Injection libs" but just "how often (or if at all) the generated instance is re-used across multiple injections".
- In Zenject, lifetimes of instances are managed by Zenject contexts (ProjectContext, SceneContext, GameObjectContext)
  - so the lifetimes cannot be specified in "InstallBindings" methods of installers
- I think that MessagePipe Lifetime does not match Zenject scopes, so any other way like this PR should be used for Zenject scopes

Thanks