### PR TITLE
Fix force change of InstanceLifetime in BindMessagePipe

### DIFF
--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Zenject/Runtime/DiContainerExtensions.cs
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Zenject/Runtime/DiContainerExtensions.cs
@@ -27,7 +27,7 @@ namespace MessagePipe
                 // so force use Scoped.
                 options.InstanceLifetime = (options.InstanceLifetime == InstanceLifetime.Singleton)
                     ? InstanceLifetime.Scoped
-                    : options.RequestHandlerLifetime;
+                    : options.InstanceLifetime;
                 options.RequestHandlerLifetime = (options.RequestHandlerLifetime == InstanceLifetime.Singleton)
                     ? InstanceLifetime.Scoped
                     : options.RequestHandlerLifetime;

--- a/src/MessagePipe.Unity/Assets/Tests/ZenjectTest.cs
+++ b/src/MessagePipe.Unity/Assets/Tests/ZenjectTest.cs
@@ -14,7 +14,7 @@ using System.Collections;
 public class ZenjectTest
 {
     [Test]
-    public void SimpelePush()
+    public void SimplePush()
     {
         var resolver = TestHelper.BuildZenject((options, builder) =>
         {
@@ -136,8 +136,8 @@ public class ZenjectTest
 
         var resolver = TestHelper.BuildZenject(options =>
        {
-            // options.InstanceLifetime = InstanceLifetime.Scoped;
-            options.AddGlobalRequestHandlerFilter<MyRequestHandlerFilter>(-1799);
+           // options.InstanceLifetime = InstanceLifetime.Scoped;
+           options.AddGlobalRequestHandlerFilter<MyRequestHandlerFilter>(-1799);
        }, (options, builder) =>
        {
            builder.BindInstance(store);

--- a/src/MessagePipe.Unity/Assets/Tests/ZenjectTest.cs
+++ b/src/MessagePipe.Unity/Assets/Tests/ZenjectTest.cs
@@ -195,6 +195,48 @@ public class ZenjectTest
         CollectionAssert.AreEqual(new[] { 9999, 333, 333, 11, 11, 4 }, l);
     }
 
+    [Test]
+    public void InstanceLifetimeSingleToScopedInBindMessagePipe()
+    {
+        var builder = new DiContainer();
+        var option = builder.BindMessagePipe(configure =>
+        {
+            configure.InstanceLifetime = InstanceLifetime.Singleton;
+            configure.RequestHandlerLifetime = InstanceLifetime.Singleton;
+        });
+
+        Assert.AreEqual(InstanceLifetime.Scoped, option.InstanceLifetime);
+        Assert.AreEqual(InstanceLifetime.Scoped, option.RequestHandlerLifetime);
+    }
+
+    [Test]
+    public void InstanceLifetimeScopedToScopedInBindMessagePipe()
+    {
+        var builder = new DiContainer();
+        var option = builder.BindMessagePipe(configure =>
+        {
+            configure.InstanceLifetime = InstanceLifetime.Scoped;
+            configure.RequestHandlerLifetime = InstanceLifetime.Scoped;
+        });
+
+        Assert.AreEqual(InstanceLifetime.Scoped, option.InstanceLifetime);
+        Assert.AreEqual(InstanceLifetime.Scoped, option.RequestHandlerLifetime);
+    }
+
+    [Test]
+    public void InstanceLifetimeTransientToTransientInBindMessagePipe()
+    {
+        var builder = new DiContainer();
+        var option = builder.BindMessagePipe(configure =>
+        {
+            configure.InstanceLifetime = InstanceLifetime.Transient;
+            configure.RequestHandlerLifetime = InstanceLifetime.Transient;
+        });
+
+        Assert.AreEqual(InstanceLifetime.Transient, option.InstanceLifetime);
+        Assert.AreEqual(InstanceLifetime.Transient, option.RequestHandlerLifetime);
+    }
+
     public class IntClass
     {
         public int Value { get; set; }


### PR DESCRIPTION
# Changes
- Fix force change of `InstanceLifetime` in `BindMessagePipe`
  - Also add tests for it
- Fix typo and indent in `ZenjectTest`

# Other Info
I have a question.

Should `AsTransient()` be used in this line?
If using `InstanceLifetime.Transient`, `AsSingle()` will be called in this line.

https://github.com/Cysharp/MessagePipe/blob/3ea773a41f705f65cc187ccc9c328c9423cb35bf/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Zenject/Runtime/TypeProxy.cs#L48

If so, I will push an additional commit for it (https://github.com/tsgcpp/MessagePipe/commit/0ac187b5b5abcf5be1153f8865e03c4e0625e019)