### PR TITLE
Fix to use "AsTransient" if InstanceLifetime is Transient

### DIFF
--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Zenject/Runtime/TypeProxy.cs
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Zenject/Runtime/TypeProxy.cs
@@ -39,25 +39,25 @@ namespace MessagePipe.Zenject
 
         public void Add(Type type, InstanceLifetime lifetime)
         {
-            if (lifetime == InstanceLifetime.Scoped)
-            {
-                builder.Bind(type).AsCached();
-            }
-            else
-            {
-                builder.Bind(type).AsSingle();
-            }
+            var binder = builder.Bind(type);
+            SetScope(binder, lifetime);
         }
 
         public void Add(Type serviceType, Type implementationType, InstanceLifetime lifetime)
         {
-            if (lifetime == InstanceLifetime.Scoped)
+            var binder = builder.Bind(serviceType).To(implementationType);
+            SetScope(binder, lifetime);
+        }
+
+        private void SetScope(ScopeConcreteIdArgConditionCopyNonLazyBinder binder, InstanceLifetime lifetime)
+        {
+            if (lifetime == InstanceLifetime.Transient)
             {
-                builder.Bind(serviceType).To(implementationType).AsCached();
+                binder.AsTransient();
             }
             else
             {
-                builder.Bind(serviceType).To(implementationType).AsSingle();
+                binder.AsCached();
             }
         }
     }

--- a/src/MessagePipe.Unity/Assets/Tests/ZenjectTest.cs
+++ b/src/MessagePipe.Unity/Assets/Tests/ZenjectTest.cs
@@ -237,6 +237,42 @@ public class ZenjectTest
         Assert.AreEqual(InstanceLifetime.Transient, option.RequestHandlerLifetime);
     }
 
+    [Test]
+    public void BindMessageBrokerWithLifetimeScoped()
+    {
+        var resolver = TestHelper.BuildZenject((options, builder) =>
+        {
+            options.InstanceLifetime = InstanceLifetime.Scoped;
+            builder.BindMessageBroker<int>(options);
+        });
+
+        var pub1 = resolver.Resolve<IPublisher<int>>();
+        var pub2 = resolver.Resolve<IPublisher<int>>();
+        var sub1 = resolver.Resolve<ISubscriber<int>>();
+        var sub2 = resolver.Resolve<ISubscriber<int>>();
+
+        Assert.AreEqual(pub1, pub2);
+        Assert.AreEqual(sub1, sub2);
+    }
+
+    [Test]
+    public void BindMessageBrokerWithLifetimeTransient()
+    {
+        var resolver = TestHelper.BuildZenject((options, builder) =>
+        {
+            options.InstanceLifetime = InstanceLifetime.Transient;
+            builder.BindMessageBroker<int>(options);
+        });
+
+        var pub1 = resolver.Resolve<IPublisher<int>>();
+        var pub2 = resolver.Resolve<IPublisher<int>>();
+        var sub1 = resolver.Resolve<ISubscriber<int>>();
+        var sub2 = resolver.Resolve<ISubscriber<int>>();
+
+        Assert.AreNotEqual(pub1, pub2);
+        Assert.AreNotEqual(sub1, sub2);
+    }
+
     public class IntClass
     {
         public int Value { get; set; }


### PR DESCRIPTION
I'm sorry if I'm wrong.
If using InstanceLifetime.Transient, AsSingle() seems to be used.

# Changes
- Fix to use "AsTransient" if InstanceLifetime is Transient