### PR TITLE
Interim support for duplex named pipe communication and client recovery

### DIFF
--- a/src/MessagePipe.Interprocess/MessagePipeInterprocessOptions.cs
+++ b/src/MessagePipe.Interprocess/MessagePipeInterprocessOptions.cs
@@ -40,6 +40,8 @@ namespace MessagePipe.Interprocess
         public string PipeName { get; }
         public string ServerName { get; set; }
         public bool? HostAsServer { get; set; }
+        public int MaxSimultaneousServerInstances { get; set; } = 1;
+        public bool AllowClientReconnect { get; set; }
 
         public MessagePipeInterprocessNamedPipeOptions(string pipeName)
             : base()

--- a/src/MessagePipe.Interprocess/Workers/NamedPipeWorker.cs
+++ b/src/MessagePipe.Interprocess/Workers/NamedPipeWorker.cs
@@ -157,9 +157,13 @@ namespace MessagePipe.Interprocess.Workers
                     }
                     catch (IOException)
                     {
-                        client.Value.Dispose();
-                        client = CreateLazyClientStream();
-                        goto RESTART;
+                        if (options.AllowClientReconnect)
+                        {
+                            client.Value.Dispose();
+                            client = CreateLazyClientStream();
+                            goto RESTART;
+                        }
+                        return; // connection closed.
                     }
                     catch (Exception ex)
                     {
@@ -201,14 +205,10 @@ namespace MessagePipe.Interprocess.Workers
                     {
                         if (waitForConnection != null)
                         {
-                            if (options.AllowClientReconnect)
-                            {
-                                server.Value.Dispose();
-                                server = CreateLazyServerStream();
-                                pipeStream = server.Value;
-                                goto RECONNECT; // end of stream(disconnect, wait reconnect)
-                            }
-                            return; // connection closed.
+                            server.Value.Dispose();
+                            server = CreateLazyServerStream();
+                            pipeStream = server.Value;
+                            goto RECONNECT; // end of stream(disconnect, wait reconnect)
                         }
                     }
 


### PR DESCRIPTION
I added an option to allow more than one named pipe server instance to run simultaneously. This allows duplex communication between a node that is running `HostAsServer = true;` and another that is running `HostAsServer = false;`.

This is only an interim measure, as I think the long-term solution should be to use the write and read streams of the `NamedPipeClientStream` for both Publish and Receive, respectively, when `HostAsServer = false`.

I have also added an option to allow clients to reconnect to a server.

My dev testing involved creating one "server" app with `HostAsServer = true;` that has a pub and a sub (basically an echo service) and another "client" app with `HostAsServer = false`, that generated data and listened to echoes. Duplex comms worked. I could also stop and start the "client" app with the server recovering (previously, it did not recover without the "server's" client reinitialization).

Additional future work should include using a named pipe server with proper multi-instance support, similar to https://www.codeproject.com/Articles/1199046/A-Csharp-Named-Pipe-Library-That-Supports-Multiple , to allow multiple clients to connect at the same time. The application for this is when you might have a single .NET 6 app that needs to send/receive data to/from multiple .NET FX apps. This is not too unlikely of a scenario as a lot of hardware manufacturers are slow to update their SDKs to .NET 6+, so you may end up having multiple apps that need to send their data to your more modern .NET 6+ code. In this example, the .NET 6 app would be set up as a server and all the .NET FX apps would be duplex clients (the proper duplex client, not the current implementation).