### PR TITLE
Added scoped request handling support for remote requests

### DIFF
--- a/src/MessagePipe.Interprocess/MessagePipeInterprocessOptions.cs
+++ b/src/MessagePipe.Interprocess/MessagePipeInterprocessOptions.cs
@@ -9,6 +9,7 @@ namespace MessagePipe.Interprocess
         public MessagePackSerializerOptions MessagePackSerializerOptions { get; set; }
         public InstanceLifetime InstanceLifetime { get; set; }
         public Action<string, Exception> UnhandledErrorHandler { get; set; }
+        public bool ScopedRequestHandling { get; set; } = false;
 
         public MessagePipeInterprocessOptions()
         {

--- a/src/MessagePipe.Interprocess/Workers/NamedPipeWorker.cs
+++ b/src/MessagePipe.Interprocess/Workers/NamedPipeWorker.cs
@@ -245,7 +245,7 @@ namespace MessagePipe.Interprocess.Workers
                                 var header = Deserialize<RequestHeader>(message.KeyMemory, options.MessagePackSerializerOptions);
                                 var (mid, reqTypeName, resTypeName) = (header.MessageId, header.RequestType, header.ResponseType);
                                 byte[] resultBytes;
-                                AsyncServiceScope? scope = null;
+                                AsyncServiceScope scope = default;
                                 try
                                 {
                                     var t = AsyncRequestHandlerRegistory.Get(reqTypeName, resTypeName);
@@ -253,8 +253,8 @@ namespace MessagePipe.Interprocess.Workers
                                         .First(x => x.GetGenericArguments().Any(y => y.FullName == header.RequestType));
                                     var coreInterfaceType = t.GetInterfaces().Where(x => x.IsGenericType && x.Name.StartsWith("IAsyncRequestHandlerCore"))
                                         .First(x => x.GetGenericArguments().Any(y => y.FullName == header.RequestType));
-                                    scope = options.ScopedRequestHandling ? provider.CreateAsyncScope() : null; // Create scope if needed.
-                                    var service = (scope?.ServiceProvider ?? provider).GetRequiredService(interfaceType); // IAsyncRequestHandler<TRequest,TResponse>
+                                    scope = options.ScopedRequestHandling ? provider.CreateAsyncScope() : default; // Create scope if needed.
+                                    var service = (options.ScopedRequestHandling ? scope.ServiceProvider : provider).GetRequiredService(interfaceType); // IAsyncRequestHandler<TRequest,TResponse>
                                     var genericArgs = interfaceType.GetGenericArguments(); // [TRequest, TResponse]
                                     var request = MessagePackSerializer.Deserialize(genericArgs[0], message.ValueMemory, options.MessagePackSerializerOptions);
                                     var responseTask = coreInterfaceType.GetMethod("InvokeAsync")!.Invoke(service, new[] { request, CancellationToken.None });
@@ -271,9 +271,9 @@ namespace MessagePipe.Interprocess.Workers
                                 }
                                 finally
                                 {
-                                    if (scope != null)
+                                    if (!scope.Equals(default(AsyncServiceScope)))
                                     {
-                                        await scope.Value.DisposeAsync().ConfigureAwait(false);
+                                        await scope.DisposeAsync().ConfigureAwait(false);
                                     }
                                 }
 

--- a/src/MessagePipe.Interprocess/Workers/NamedPipeWorker.cs
+++ b/src/MessagePipe.Interprocess/Workers/NamedPipeWorker.cs
@@ -271,7 +271,10 @@ namespace MessagePipe.Interprocess.Workers
                                 }
                                 finally
                                 {
-                                    scope?.Dispose();
+                                    if (scope != null)
+                                    {
+                                        await scope.Value.DisposeAsync().ConfigureAwait(false);
+                                    }
                                 }
 
                                 await pipeStream.WriteAsync(resultBytes, 0, resultBytes.Length).ConfigureAwait(false);

--- a/src/MessagePipe.Interprocess/Workers/NamedPipeWorker.cs
+++ b/src/MessagePipe.Interprocess/Workers/NamedPipeWorker.cs
@@ -245,6 +245,7 @@ namespace MessagePipe.Interprocess.Workers
                                 var header = Deserialize<RequestHeader>(message.KeyMemory, options.MessagePackSerializerOptions);
                                 var (mid, reqTypeName, resTypeName) = (header.MessageId, header.RequestType, header.ResponseType);
                                 byte[] resultBytes;
+                                AsyncServiceScope? scope = null;
                                 try
                                 {
                                     var t = AsyncRequestHandlerRegistory.Get(reqTypeName, resTypeName);
@@ -252,19 +253,25 @@ namespace MessagePipe.Interprocess.Workers
                                         .First(x => x.GetGenericArguments().Any(y => y.FullName == header.RequestType));
                                     var coreInterfaceType = t.GetInterfaces().Where(x => x.IsGenericType && x.Name.StartsWith("IAsyncRequestHandlerCore"))
                                         .First(x => x.GetGenericArguments().Any(y => y.FullName == header.RequestType));
-                                    var service = provider.GetRequiredService(interfaceType); // IAsyncRequestHandler<TRequest,TResponse>
+                                    scope = options.ScopedRequestHandling ? provider.CreateAsyncScope() : null; // Create scope if needed.
+                                    var service = (scope?.ServiceProvider ?? provider).GetRequiredService(interfaceType); // IAsyncRequestHandler<TRequest,TResponse>
                                     var genericArgs = interfaceType.GetGenericArguments(); // [TRequest, TResponse]
                                     var request = MessagePackSerializer.Deserialize(genericArgs[0], message.ValueMemory, options.MessagePackSerializerOptions);
                                     var responseTask = coreInterfaceType.GetMethod("InvokeAsync")!.Invoke(service, new[] { request, CancellationToken.None });
                                     var task = typeof(ValueTask<>).MakeGenericType(genericArgs[1]).GetMethod("AsTask")!.Invoke(responseTask, null);
                                     await ((System.Threading.Tasks.Task)task!); // Task<T> -> Task
                                     var result = task.GetType().GetProperty("Result")!.GetValue(task);
+
                                     resultBytes = MessageBuilder.BuildRemoteResponseMessage(mid, genericArgs[1], result!, options.MessagePackSerializerOptions);
                                 }
                                 catch (Exception ex)
                                 {
                                     // NOTE: ok to send stacktrace?
                                     resultBytes = MessageBuilder.BuildRemoteResponseError(mid, ex.ToString(), options.MessagePackSerializerOptions);
+                                }
+                                finally
+                                {
+                                    scope?.Dispose();
                                 }
 
                                 await pipeStream.WriteAsync(resultBytes, 0, resultBytes.Length).ConfigureAwait(false);

--- a/src/MessagePipe.Interprocess/Workers/TcpWorker.cs
+++ b/src/MessagePipe.Interprocess/Workers/TcpWorker.cs
@@ -292,7 +292,10 @@ namespace MessagePipe.Interprocess.Workers
                                 }
                                 finally
                                 {
-                                    scope?.Dispose();
+                                    if(scope != null)
+                                    {
+                                        await scope.Value.DisposeAsync().ConfigureAwait(false);
+                                    }
                                 }
 
                                 await client.SendAsync(resultBytes).ConfigureAwait(false);

--- a/src/MessagePipe.Interprocess/Workers/TcpWorker.cs
+++ b/src/MessagePipe.Interprocess/Workers/TcpWorker.cs
@@ -260,6 +260,7 @@ namespace MessagePipe.Interprocess.Workers
                                 var header = Deserialize<RequestHeader>(message.KeyMemory, options.MessagePackSerializerOptions);
                                 var (mid, reqTypeName, resTypeName) = (header.MessageId, header.RequestType, header.ResponseType);
                                 byte[] resultBytes;
+                                AsyncServiceScope? scope = null;
                                 try
                                 {
                                     var t = AsyncRequestHandlerRegistory.Get(reqTypeName, resTypeName);
@@ -267,7 +268,8 @@ namespace MessagePipe.Interprocess.Workers
                                         .First(x => x.GetGenericArguments().Any(y => y.FullName == header.RequestType));
                                     var coreInterfaceType = t.GetInterfaces().Where(x => x.IsGenericType && x.Name.StartsWith("IAsyncRequestHandlerCore"))
                                         .First(x => x.GetGenericArguments().Any(y => y.FullName == header.RequestType));
-                                    var service = provider.GetRequiredService(interfaceType); // IAsyncRequestHandler<TRequest,TResponse>
+                                    scope = options.ScopedRequestHandling ? provider.CreateAsyncScope() : null; // Create scope if needed.
+                                    var service = (scope?.ServiceProvider ?? provider).GetRequiredService(interfaceType); // IAsyncRequestHandler<TRequest,TResponse>
                                     var genericArgs = interfaceType.GetGenericArguments(); // [TRequest, TResponse]
                                     // Unity IL2CPP does not work(can not invoke nongenerics MessagePackSerializer)
                                     var request = MessagePackSerializer.Deserialize(genericArgs[0], message.ValueMemory, options.MessagePackSerializerOptions);
@@ -287,6 +289,10 @@ namespace MessagePipe.Interprocess.Workers
                                 {
                                     // NOTE: ok to send stacktrace?
                                     resultBytes = MessageBuilder.BuildRemoteResponseError(mid, ex.ToString(), options.MessagePackSerializerOptions);
+                                }
+                                finally
+                                {
+                                    scope?.Dispose();
                                 }
 
                                 await client.SendAsync(resultBytes).ConfigureAwait(false);

--- a/src/MessagePipe.Interprocess/Workers/TcpWorker.cs
+++ b/src/MessagePipe.Interprocess/Workers/TcpWorker.cs
@@ -260,7 +260,7 @@ namespace MessagePipe.Interprocess.Workers
                                 var header = Deserialize<RequestHeader>(message.KeyMemory, options.MessagePackSerializerOptions);
                                 var (mid, reqTypeName, resTypeName) = (header.MessageId, header.RequestType, header.ResponseType);
                                 byte[] resultBytes;
-                                AsyncServiceScope? scope = null;
+                                AsyncServiceScope scope = default;
                                 try
                                 {
                                     var t = AsyncRequestHandlerRegistory.Get(reqTypeName, resTypeName);
@@ -268,8 +268,8 @@ namespace MessagePipe.Interprocess.Workers
                                         .First(x => x.GetGenericArguments().Any(y => y.FullName == header.RequestType));
                                     var coreInterfaceType = t.GetInterfaces().Where(x => x.IsGenericType && x.Name.StartsWith("IAsyncRequestHandlerCore"))
                                         .First(x => x.GetGenericArguments().Any(y => y.FullName == header.RequestType));
-                                    scope = options.ScopedRequestHandling ? provider.CreateAsyncScope() : null; // Create scope if needed.
-                                    var service = (scope?.ServiceProvider ?? provider).GetRequiredService(interfaceType); // IAsyncRequestHandler<TRequest,TResponse>
+                                    scope = options.ScopedRequestHandling ? provider.CreateAsyncScope() : default; // Create scope if needed.
+                                    var service = (options.ScopedRequestHandling ? scope.ServiceProvider : provider).GetRequiredService(interfaceType); // IAsyncRequestHandler<TRequest,TResponse>
                                     var genericArgs = interfaceType.GetGenericArguments(); // [TRequest, TResponse]
                                     // Unity IL2CPP does not work(can not invoke nongenerics MessagePackSerializer)
                                     var request = MessagePackSerializer.Deserialize(genericArgs[0], message.ValueMemory, options.MessagePackSerializerOptions);
@@ -292,9 +292,9 @@ namespace MessagePipe.Interprocess.Workers
                                 }
                                 finally
                                 {
-                                    if(scope != null)
+                                    if(!scope.Equals(default(AsyncServiceScope)))
                                     {
-                                        await scope.Value.DisposeAsync().ConfigureAwait(false);
+                                        await scope.DisposeAsync().ConfigureAwait(false);
                                     }
                                 }
 

--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Interprocess/Runtime/MessagePipeInterprocessOptions.cs
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Interprocess/Runtime/MessagePipeInterprocessOptions.cs
@@ -9,6 +9,7 @@ namespace MessagePipe.Interprocess
         public MessagePackSerializerOptions MessagePackSerializerOptions { get; set; }
         public InstanceLifetime InstanceLifetime { get; set; }
         public Action<string, Exception> UnhandledErrorHandler { get; set; }
+        public bool ScopedRequestHandling { get; set; } = false;
 
         public MessagePipeInterprocessOptions()
         {

--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Interprocess/Runtime/Workers/NamedPipeWorker.cs
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Interprocess/Runtime/Workers/NamedPipeWorker.cs
@@ -245,6 +245,7 @@ namespace MessagePipe.Interprocess.Workers
                                 var header = Deserialize<RequestHeader>(message.KeyMemory, options.MessagePackSerializerOptions);
                                 var (mid, reqTypeName, resTypeName) = (header.MessageId, header.RequestType, header.ResponseType);
                                 byte[] resultBytes;
+                                AsyncServiceScope? scope = null;
                                 try
                                 {
                                     var t = AsyncRequestHandlerRegistory.Get(reqTypeName, resTypeName);
@@ -252,19 +253,25 @@ namespace MessagePipe.Interprocess.Workers
                                         .First(x => x.GetGenericArguments().Any(y => y.FullName == header.RequestType));
                                     var coreInterfaceType = t.GetInterfaces().Where(x => x.IsGenericType && x.Name.StartsWith("IAsyncRequestHandlerCore"))
                                         .First(x => x.GetGenericArguments().Any(y => y.FullName == header.RequestType));
-                                    var service = provider.GetRequiredService(interfaceType); // IAsyncRequestHandler<TRequest,TResponse>
+                                    scope = options.ScopedRequestHandling ? provider.CreateAsyncScope() : null; // Create scope if needed.
+                                    var service = (scope?.ServiceProvider ?? provider).GetRequiredService(interfaceType); // IAsyncRequestHandler<TRequest,TResponse>
                                     var genericArgs = interfaceType.GetGenericArguments(); // [TRequest, TResponse]
                                     var request = MessagePackSerializer.Deserialize(genericArgs[0], message.ValueMemory, options.MessagePackSerializerOptions);
                                     var responseTask = coreInterfaceType.GetMethod("InvokeAsync").Invoke(service, new[] { request, CancellationToken.None });
                                     var task = typeof(UniTask<>).MakeGenericType(genericArgs[1]).GetMethod("AsTask").Invoke(responseTask, null);
                                     await ((System.Threading.Tasks.Task)task); // Task<T> -> Task
                                     var result = task.GetType().GetProperty("Result").GetValue(task);
+
                                     resultBytes = MessageBuilder.BuildRemoteResponseMessage(mid, genericArgs[1], result, options.MessagePackSerializerOptions);
                                 }
                                 catch (Exception ex)
                                 {
                                     // NOTE: ok to send stacktrace?
                                     resultBytes = MessageBuilder.BuildRemoteResponseError(mid, ex.ToString(), options.MessagePackSerializerOptions);
+                                }
+                                finally
+                                {
+                                    scope?.Dispose();
                                 }
 
                                 await pipeStream.WriteAsync(resultBytes, 0, resultBytes.Length).ConfigureAwait(false);

--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Interprocess/Runtime/Workers/TcpWorker.cs
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Interprocess/Runtime/Workers/TcpWorker.cs
@@ -260,6 +260,7 @@ namespace MessagePipe.Interprocess.Workers
                                 var header = Deserialize<RequestHeader>(message.KeyMemory, options.MessagePackSerializerOptions);
                                 var (mid, reqTypeName, resTypeName) = (header.MessageId, header.RequestType, header.ResponseType);
                                 byte[] resultBytes;
+                                AsyncServiceScope? scope = null;
                                 try
                                 {
                                     var t = AsyncRequestHandlerRegistory.Get(reqTypeName, resTypeName);
@@ -267,7 +268,8 @@ namespace MessagePipe.Interprocess.Workers
                                         .First(x => x.GetGenericArguments().Any(y => y.FullName == header.RequestType));
                                     var coreInterfaceType = t.GetInterfaces().Where(x => x.IsGenericType && x.Name.StartsWith("IAsyncRequestHandlerCore"))
                                         .First(x => x.GetGenericArguments().Any(y => y.FullName == header.RequestType));
-                                    var service = provider.GetRequiredService(interfaceType); // IAsyncRequestHandler<TRequest,TResponse>
+                                    scope = options.ScopedRequestHandling ? provider.CreateAsyncScope() : null; // Create scope if needed.
+                                    var service = (scope?.ServiceProvider ?? provider).GetRequiredService(interfaceType); // IAsyncRequestHandler<TRequest,TResponse>
                                     var genericArgs = interfaceType.GetGenericArguments(); // [TRequest, TResponse]
                                     // Unity IL2CPP does not work(can not invoke nongenerics MessagePackSerializer)
                                     var request = MessagePackSerializer.Deserialize(genericArgs[0], message.ValueMemory, options.MessagePackSerializerOptions);
@@ -287,6 +289,10 @@ namespace MessagePipe.Interprocess.Workers
                                 {
                                     // NOTE: ok to send stacktrace?
                                     resultBytes = MessageBuilder.BuildRemoteResponseError(mid, ex.ToString(), options.MessagePackSerializerOptions);
+                                }
+                                finally
+                                {
+                                    scope?.Dispose();
                                 }
 
                                 await client.SendAsync(resultBytes).ConfigureAwait(false);

--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Interprocess/Runtime/Workers/TcpWorker.cs
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Interprocess/Runtime/Workers/TcpWorker.cs
@@ -260,7 +260,7 @@ namespace MessagePipe.Interprocess.Workers
                                 var header = Deserialize<RequestHeader>(message.KeyMemory, options.MessagePackSerializerOptions);
                                 var (mid, reqTypeName, resTypeName) = (header.MessageId, header.RequestType, header.ResponseType);
                                 byte[] resultBytes;
-                                AsyncServiceScope? scope = null;
+                                AsyncServiceScope scope = default;
                                 try
                                 {
                                     var t = AsyncRequestHandlerRegistory.Get(reqTypeName, resTypeName);
@@ -268,8 +268,8 @@ namespace MessagePipe.Interprocess.Workers
                                         .First(x => x.GetGenericArguments().Any(y => y.FullName == header.RequestType));
                                     var coreInterfaceType = t.GetInterfaces().Where(x => x.IsGenericType && x.Name.StartsWith("IAsyncRequestHandlerCore"))
                                         .First(x => x.GetGenericArguments().Any(y => y.FullName == header.RequestType));
-                                    scope = options.ScopedRequestHandling ? provider.CreateAsyncScope() : null; // Create scope if needed.
-                                    var service = (scope?.ServiceProvider ?? provider).GetRequiredService(interfaceType); // IAsyncRequestHandler<TRequest,TResponse>
+                                    scope = options.ScopedRequestHandling ? provider.CreateAsyncScope() : default; // Create scope if needed.
+                                    var service = (options.ScopedRequestHandling ? scope.ServiceProvider : provider).GetRequiredService(interfaceType); // IAsyncRequestHandler<TRequest,TResponse>
                                     var genericArgs = interfaceType.GetGenericArguments(); // [TRequest, TResponse]
                                     // Unity IL2CPP does not work(can not invoke nongenerics MessagePackSerializer)
                                     var request = MessagePackSerializer.Deserialize(genericArgs[0], message.ValueMemory, options.MessagePackSerializerOptions);
@@ -292,7 +292,10 @@ namespace MessagePipe.Interprocess.Workers
                                 }
                                 finally
                                 {
-                                    scope?.Dispose();
+                                    if(!scope.Equals(default(AsyncServiceScope)))
+                                    {
+                                        await scope.DisposeAsync().ConfigureAwait(false);
+                                    }
                                 }
 
                                 await client.SendAsync(resultBytes).ConfigureAwait(false);

--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe/Runtime/IRequestHandler.cs
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe/Runtime/IRequestHandler.cs
@@ -53,7 +53,6 @@ namespace MessagePipe
     // Remote
 
     public interface IRemoteRequestHandler<in TRequest, TResponse>
-    // where TAsyncRequestHandler : IAsyncRequestHandler<TRequest, TResponse>
     {
         UniTask<TResponse> InvokeAsync(TRequest request, CancellationToken cancellationToken = default);
     }

--- a/src/MessagePipe/IRequestHandler.cs
+++ b/src/MessagePipe/IRequestHandler.cs
@@ -53,7 +53,6 @@ namespace MessagePipe
     // Remote
 
     public interface IRemoteRequestHandler<in TRequest, TResponse>
-    // where TAsyncRequestHandler : IAsyncRequestHandler<TRequest, TResponse>
     {
         ValueTask<TResponse> InvokeAsync(TRequest request, CancellationToken cancellationToken = default);
     }

--- a/tests/MessagePipe.Interprocess.Tests/TcpTest.cs
+++ b/tests/MessagePipe.Interprocess.Tests/TcpTest.cs
@@ -310,5 +310,109 @@ namespace MessagePipe.Interprocess.Tests
                 }
             }
         }
+
+        [Fact]
+        public async Task RemoteRequestScopedTest()
+        {
+            var provider = TestHelper.BuildServiceProviderTcp("127.0.0.1", 1355, helper, true, true);
+
+            using (provider as IDisposable)
+            {
+                var remoteHandler = provider.GetRequiredService<IRemoteRequestHandler<int, (string, string)>>();
+
+                var v = await remoteHandler.InvokeAsync(9999);
+                v.Item1.Should().Be(v.Item2);
+
+                var v2 = await remoteHandler.InvokeAsync(9999);
+                v2.Item1.Should().Be(v2.Item2);
+
+                v.Item1.Should().NotBe(v2.Item1);
+            }
+        }
+
+        [Fact]
+        public async Task RemoteRequestNotScopedTest()
+        {
+            var provider = TestHelper.BuildServiceProviderTcp("127.0.0.1", 1355, helper, true, false);
+            using (provider as IDisposable)
+            {
+                var remoteHandler = provider.GetRequiredService<IRemoteRequestHandler<int, (string, string)>>();
+
+                var v = await remoteHandler.InvokeAsync(9999);
+                v.Item1.Should().Be(v.Item2);
+
+                var v2 = await remoteHandler.InvokeAsync(9999);
+                v2.Item1.Should().Be(v2.Item2);
+
+                v.Item1.Should().Be(v2.Item1);
+            }
+        }
+
+        [Fact]
+        public async Task RemoteRequestWithUdsScopedTest()
+        {
+            var filePath = System.IO.Path.GetTempFileName();
+            if (System.IO.File.Exists(filePath))
+            {
+                System.IO.File.Delete(filePath);
+            }
+            try
+            {
+                var provider = TestHelper.BuildServiceProviderTcpWithUds(filePath, helper, true, true);
+
+                using (provider as IDisposable)
+                {
+                    var remoteHandler = provider.GetRequiredService<IRemoteRequestHandler<int, (string, string)>>();
+
+                    var v = await remoteHandler.InvokeAsync(9999);
+                    v.Item1.Should().Be(v.Item2);
+
+                    var v2 = await remoteHandler.InvokeAsync(9999);
+                    v2.Item1.Should().Be(v2.Item2);
+
+                    v.Item1.Should().NotBe(v2.Item1);
+                }
+            }
+            finally
+            {
+                if (System.IO.File.Exists(filePath))
+                {
+                    System.IO.File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task RemoteRequestWithUdsNotScopedTest()
+        {
+            var filePath = System.IO.Path.GetTempFileName();
+            if (System.IO.File.Exists(filePath))
+            {
+                System.IO.File.Delete(filePath);
+            }
+            try
+            {
+                var provider = TestHelper.BuildServiceProviderTcpWithUds(filePath, helper, true, false);
+                using (provider as IDisposable)
+                {
+                    var remoteHandler = provider.GetRequiredService<IRemoteRequestHandler<int, (string, string)>>();
+
+                    var v = await remoteHandler.InvokeAsync(9999);
+                    v.Item1.Should().Be(v.Item2);
+
+                    var v2 = await remoteHandler.InvokeAsync(9999);
+                    v2.Item1.Should().Be(v2.Item2);
+
+                    v.Item1.Should().Be(v2.Item1);
+                }
+            }
+            finally
+            {
+                if (System.IO.File.Exists(filePath))
+                {
+                    System.IO.File.Delete(filePath);
+                }
+            }
+        }
     }
 }

--- a/tests/MessagePipe.Interprocess.Tests/_TestHelper.cs
+++ b/tests/MessagePipe.Interprocess.Tests/_TestHelper.cs
@@ -6,27 +6,37 @@ namespace MessagePipe.Interprocess.Tests
 {
     public static class TestHelper
     {
-        public static IServiceProvider BuildServiceProviderUdp(string host, int port, ITestOutputHelper helper)
+        public static IServiceProvider BuildServiceProviderUdp(string host, int port, ITestOutputHelper helper, bool? scoped = false)
         {
             var sc = new ServiceCollection();
             sc.AddMessagePipe();
             sc.AddMessagePipeUdpInterprocess(host, port, x =>
             {
                 x.UnhandledErrorHandler = (msg, e) => helper.WriteLine(msg + e);
+                x.ScopedRequestHandling = scoped ?? false;
             });
+            if (scoped.HasValue)
+            {
+                sc.AddScoped<ScopeTestService>();
+            }
             return sc.BuildServiceProvider();
         }
-        public static IServiceProvider BuildServiceProviderUdpWithUds(string domainSocketPath, ITestOutputHelper helper)
+        public static IServiceProvider BuildServiceProviderUdpWithUds(string domainSocketPath, ITestOutputHelper helper, bool? scoped = false)
         {
             var sc = new ServiceCollection();
             sc.AddMessagePipe();
             sc.AddMessagePipeUdpInterprocessUds(domainSocketPath, x =>
             {
                 x.UnhandledErrorHandler = (msg, e) => helper.WriteLine(msg + e);
+                x.ScopedRequestHandling = scoped ?? false;
             });
+            if (scoped.HasValue)
+            {
+                sc.AddScoped<ScopeTestService>();
+            }
             return sc.BuildServiceProvider();
         }
-        public static IServiceProvider BuildServiceProviderTcp(string host, int port, ITestOutputHelper helper, bool asServer = true)
+        public static IServiceProvider BuildServiceProviderTcp(string host, int port, ITestOutputHelper helper, bool asServer = true, bool? scoped = false)
         {
             var sc = new ServiceCollection();
             sc.AddMessagePipe();
@@ -34,10 +44,15 @@ namespace MessagePipe.Interprocess.Tests
             {
                 x.HostAsServer = asServer;
                 x.UnhandledErrorHandler = (msg, e) => helper.WriteLine(msg + e);
+                x.ScopedRequestHandling = scoped ?? false;
             });
+            if (scoped.HasValue)
+            {
+                sc.AddScoped<ScopeTestService>();
+            }
             return sc.BuildServiceProvider();
         }
-        public static IServiceProvider BuildServiceProviderTcpWithUds(string domainSocketPath, ITestOutputHelper helper, bool asServer = true)
+        public static IServiceProvider BuildServiceProviderTcpWithUds(string domainSocketPath, ITestOutputHelper helper, bool asServer = true, bool? scoped = false)
         {
             var sc = new ServiceCollection();
             sc.AddMessagePipe();
@@ -45,11 +60,16 @@ namespace MessagePipe.Interprocess.Tests
             {
                 x.HostAsServer = asServer;
                 x.UnhandledErrorHandler = (msg, e) => helper.WriteLine(msg + e);
+                x.ScopedRequestHandling = scoped ?? false;
             });
+            if (scoped.HasValue)
+            {
+                sc.AddScoped<ScopeTestService>();
+            }
             return sc.BuildServiceProvider();
         }
 
-        public static IServiceProvider BuildServiceProviderNamedPipe(string pipeName, ITestOutputHelper helper, bool asServer = true)
+        public static IServiceProvider BuildServiceProviderNamedPipe(string pipeName, ITestOutputHelper helper, bool asServer = true, bool? scoped = null)
         {
             var sc = new ServiceCollection();
             sc.AddMessagePipe();
@@ -57,7 +77,12 @@ namespace MessagePipe.Interprocess.Tests
             {
                 x.HostAsServer = asServer;
                 x.UnhandledErrorHandler = (msg, e) => helper.WriteLine(msg + e);
+                x.ScopedRequestHandling = scoped ?? false;
             });
+            if (scoped.HasValue)
+            {
+                sc.AddScoped<ScopeTestService>();
+            }
             return sc.BuildServiceProvider();
         }
     }


### PR DESCRIPTION
I thought it would be nice to have the ability to scope injected services to each request.

- Added option 'ScopedRequestHandling' to 'MessagePipeInterprocessOptions'.
- Added functionality to create a scope before requesting an instance of 'remote' request handler and disposing of the scope after the request has been handled, only when 'ScopedRequestHandling' has been set to true.
- Added tests for validating if the newly added functionality works as intended. Checking whether the injected service instances are the same per request or not.

This only regards remote request handling. For handling requests for the same process this is not the responsibility of MessagePipe, since control of the scope is then out of the hands of this library.

This is my first time contributing to a project on Github, so this is pretty new for me. Any feedback is more than welcome.

P.S. Since this functionality is only applicable to TCP or named pipe based requests, the option should rather not be available for UDP message pipe options. But TCP worker references MessagePipeInterprocessOptions rather than a more specific extended MessagePipeInterprocessOptions class for only TCP connections, so I had to use to more general MessagePipeInterprocessOptions.