### PR TITLE
Support constructor injection with IConnectionMultiplexerFactory

### DIFF
--- a/src/MessagePipe.Redis/MessagePipeRedisOptions.cs
+++ b/src/MessagePipe.Redis/MessagePipeRedisOptions.cs
@@ -15,13 +15,11 @@ namespace MessagePipe.Redis
 
     public sealed class MessagePipeRedisOptions
     {
-        public IConnectionMultiplexerFactory ConnectionMultiplexerFactory { get; }
         public IRedisSerializer RedisSerializer { get; set; }
 
-        public MessagePipeRedisOptions(IConnectionMultiplexerFactory connectionMultiplexerFactory)
+        public MessagePipeRedisOptions()
         {
             this.RedisSerializer = new MessagePackRedisSerializer();
-            this.ConnectionMultiplexerFactory = connectionMultiplexerFactory;
         }
     }
 }

--- a/tests/MessagePipe.Redis.Tests/ConnectionMultiplexerFactoryTest.cs
+++ b/tests/MessagePipe.Redis.Tests/ConnectionMultiplexerFactoryTest.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MessagePipe.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using StackExchange.Redis;
+using Xunit;
+
+namespace MessagePipe.Redis.Tests;
+
+public class ConnectionMultiplexerFactoryTest
+{
+    [Fact]
+    public async Task CreateFromInstance()
+    {
+        var connection = TestHelper.GetLocalConnectionMultiplexer();
+        var services = new ServiceCollection();
+        services.AddMessagePipe();
+        services.AddMessagePipeRedis(connection);
+        var sp = services.BuildServiceProvider();
+
+        var publisher = sp.GetRequiredService<IDistributedPublisher<string, string>>();
+        var subscriber = sp.GetRequiredService<IDistributedSubscriber<string, string>>();
+     
+        var results = new List<string>();
+        await using var _ = await subscriber.SubscribeAsync("Foo", x => results.Add(x));
+
+        await publisher.PublishAsync("Foo", "Bar");
+        await Task.Delay(250);
+        results.FirstOrDefault().Should().Be("Bar");
+    }
+
+    [Fact]
+    public async Task CreateFromGenericType()
+    {
+        var connection = TestHelper.GetLocalConnectionMultiplexer();
+        var services = new ServiceCollection();
+        services.AddSingleton<IConnectionMultiplexer>(connection);
+        services.AddMessagePipe();
+        services.AddMessagePipeRedis<TestConnectionMultiplexerFactory>();
+        var sp = services.BuildServiceProvider();
+
+        var publisher = sp.GetRequiredService<IDistributedPublisher<string, string>>();
+        var subscriber = sp.GetRequiredService<IDistributedSubscriber<string, string>>();
+     
+        var results = new List<string>();
+        await using var _ = await subscriber.SubscribeAsync("Foo", x => results.Add(x));
+
+        await publisher.PublishAsync("Foo", "Bar");
+        await Task.Delay(250);
+        results.FirstOrDefault().Should().Be("Bar");
+    }
+
+    public class TestConnectionMultiplexerFactory : IConnectionMultiplexerFactory
+    {
+        readonly IConnectionMultiplexer connectionMultiplexer;
+
+        public TestConnectionMultiplexerFactory(IConnectionMultiplexer connectionMultiplexer)
+        {
+            this.connectionMultiplexer = connectionMultiplexer;
+        }
+
+        public IConnectionMultiplexer GetConnectionMultiplexer<TKey>(TKey key)
+        {
+            return connectionMultiplexer;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support constructor injection with IConnectionMultiplexerFactory.
This covers use cases where you want to use registered services or options when getting `IConnectionMultiplexerFactory`.

```csharp
services.AddMesagePipeRedis<MyConnectionMultiplexerFactory>();
...

class MyConnectionMultiplexerFactory : IConnectionMultiplexerFactory
{
    public MyConnectionMultiplexerFactory(IOptions<MyConnectionMultiplexerOption> options) { ... }
}
```

## Breaking changes
- Remove `ConnectionMultiplexerFactory` property from `MessagePipeRedisOptions`