### PR TITLE
Switch to builder style API

### DIFF
--- a/README.md
+++ b/README.md
@@ -975,16 +975,16 @@ For Unity, requires to import MessagePack-CSharp package and needs slightly diff
 var builder = new ContainerBuilder();
 var options = builder.RegisterMessagePipe(configure);
 
-var sc = builder.AsServiceCollection(); // require to convert ServiceCollection to enable Intereprocess
+var messagePipeBuilder = builder.ToMessagePipeBuilder(); // require to convert ServiceCollection to enable Intereprocess
 
-var interprocessOptions = sc.AddMessagePipeTcpInterprocess();
+var interprocessOptions = messagePipeBuilder.AddTcpInterprocess();
 
 // register manually.
 // IDistributedPublisher/Subscriber
-sc.RegisterTcpInterprocessMessageBroker<int, int>(interprocessOptions);
+messagePipeBuilder.RegisterTcpInterprocessMessageBroker<int, int>(interprocessOptions);
 // RemoteHandler
 builder.RegisterAsyncRequestHandler<int, string, MyAsyncHandler>(options); // for server
-sc.RegisterTcpRemoteRequestHandler<int, string>(interprocessOptions); // for client
+messagePipeBuilder.RegisterTcpRemoteRequestHandler<int, string>(interprocessOptions); // for client
 ```
 
 MessagePipeOptions

--- a/README.md
+++ b/README.md
@@ -822,8 +822,8 @@ use `AddMessagePipeRedis` to enable redis provider.
 Host.CreateDefaultBuilder()
     .ConfigureServices((ctx, services) =>
     {
-        services.AddMessagePipe();
-        services.AddMessagePipeRedis(IConnectionMultiplexer | IConnectionMultiplexerFactory, configure);
+        services.AddMessagePipe()
+            .AddRedis(IConnectionMultiplexer | IConnectionMultiplexerFactory, configure);
     })
 ```
 
@@ -863,7 +863,7 @@ Host.CreateDefaultBuilder()
         else
         {
             // use Redis IDistributedPublisher/Subscriber
-            builder.AddMessagePipeRedis();
+            builder.AddRedis();
         }
     });
 ```
@@ -876,18 +876,18 @@ For the interprocess(NamedPipe/UDP/TCP) Pub/Sub(IPC), you can use `IDistributedP
 
 MessagePipe.Interprocess is also exsits on Unity(except NamedPipe).
 
-use `AddMessagePipeUdpInterprocess`, `AddMessagePipeTcpInterprocess`, `AddMessagePipeNamedPipeInterprocess`, `AddMessagePipeUdpInterprocessUds`, `AddMessagePipeTcpInterprocessUds` to enable interprocess provider(Uds is Unix domain socket, most performant option).
+use `AddUdpInterprocess`, `AddTcpInterprocess`, `AddNamedPipeInterprocess`, `AddUdpInterprocessUds`, `AddTcpInterprocessUds` to enable interprocess provider(Uds is Unix domain socket, most performant option).
 
 ```csharp
 Host.CreateDefaultBuilder()
     .ConfigureServices((ctx, services) =>
     {
         services.AddMessagePipe()
-            .AddMessagePipeUdpInterprocess("127.0.0.1", 3215, configure); // setup host and port.
-            // .AddMessagePipeTcpInterprocess("127.0.0.1", 3215, configure);
-            // .AddMessagePipeNamedPipeInterprocess("messagepipe-namedpipe", configure);
-            // .AddMessagePipeUdpInterprocessUds("domainSocketPath")
-            // .AddMessagePipeTcpInterprocessUds("domainSocketPath")
+            .AddUdpInterprocess("127.0.0.1", 3215, configure); // setup host and port.
+            // .AddTcpInterprocess("127.0.0.1", 3215, configure);
+            // .AddNamedPipeInterprocess("messagepipe-namedpipe", configure);
+            // .AddUdpInterprocessUds("domainSocketPath")
+            // .AddTcpInterprocessUds("domainSocketPath")
     })
 ```
 
@@ -919,7 +919,7 @@ Tcp has no such restrictions and is the most flexible of all the options.
 In default uses [MessagePack for C#](https://github.com/neuecc/MessagePack-CSharp)'s `ContractlessStandardResolver` for message serialization. You can change to use other `MessagePackSerializerOptions` by MessagePipeInterprocessOptions.MessagePackSerializerOptions.
 
 ```csharp
-services.AddMessagePipeUdpInterprocess("127.0.0.1", 3215, options =>
+builder.AddUdpInterprocess("127.0.0.1", 3215, options =>
 {
     // You can configure other options, `InstanceLifetime` and `UnhandledErrorHandler`.
     options.MessagePackSerializerOptions = StandardResolver.Options;
@@ -933,7 +933,7 @@ Host.CreateDefaultBuilder()
     .ConfigureServices((ctx, services) =>
     {
         services.AddMessagePipe()
-            .AddMessagePipeTcpInterprocess("127.0.0.1", 3215, x =>
+            .AddTcpInterprocess("127.0.0.1", 3215, x =>
             {
                 x.HostAsServer = true; // if remote process as server, set true(otherwise false(default)).
             });

--- a/README.md
+++ b/README.md
@@ -854,16 +854,16 @@ Host.CreateDefaultBuilder()
     {
         var config = ctx.Configuration.Get<MyConfig>();
 
-        services.AddMessagePipe();
+        var builder = services.AddMessagePipe();
         if (config.IsLocal)
         {
             // use in-memory IDistributedPublisher/Subscriber in local.
-            services.AddInMemoryDistributedMessageBroker();   
+            builder.AddInMemoryDistributedMessageBroker();   
         }
         else
         {
             // use Redis IDistributedPublisher/Subscriber
-            services.AddMessagePipeRedis();
+            builder.AddMessagePipeRedis();
         }
     });
 ```
@@ -882,12 +882,12 @@ use `AddMessagePipeUdpInterprocess`, `AddMessagePipeTcpInterprocess`, `AddMessag
 Host.CreateDefaultBuilder()
     .ConfigureServices((ctx, services) =>
     {
-        services.AddMessagePipe();
-        services.AddMessagePipeUdpInterprocess("127.0.0.1", 3215, configure); // setup host and port.
-        // services.AddMessagePipeTcpInterprocess("127.0.0.1", 3215, configure);
-        // services.AddMessagePipeNamedPipeInterprocess("messagepipe-namedpipe", configure);
-        // services.AddMessagePipeUdpInterprocessUds("domainSocketPath")
-        // services.AddMessagePipeTcpInterprocessUds("domainSocketPath")
+        services.AddMessagePipe()
+            .AddMessagePipeUdpInterprocess("127.0.0.1", 3215, configure); // setup host and port.
+            // .AddMessagePipeTcpInterprocess("127.0.0.1", 3215, configure);
+            // .AddMessagePipeNamedPipeInterprocess("messagepipe-namedpipe", configure);
+            // .AddMessagePipeUdpInterprocessUds("domainSocketPath")
+            // .AddMessagePipeTcpInterprocessUds("domainSocketPath")
     })
 ```
 
@@ -932,11 +932,11 @@ For IPC-RPC, you can use `IRemoteRequestHandler<in TRequest, TResponse>` that in
 Host.CreateDefaultBuilder()
     .ConfigureServices((ctx, services) =>
     {
-        services.AddMessagePipe();
-        services.AddMessagePipeTcpInterprocess("127.0.0.1", 3215, x =>
-        {
-            x.HostAsServer = true; // if remote process as server, set true(otherwise false(default)).
-        });
+        services.AddMessagePipe()
+            .AddMessagePipeTcpInterprocess("127.0.0.1", 3215, x =>
+            {
+                x.HostAsServer = true; // if remote process as server, set true(otherwise false(default)).
+            });
     });
 ```
 

--- a/sandbox/InterprocessServer/Program.cs
+++ b/sandbox/InterprocessServer/Program.cs
@@ -33,7 +33,7 @@ namespace InterprocessServer
                 .ConfigureServices(x =>
                 {
                     x.AddMessagePipe()
-                        .AddMessagePipeNamedPipeInterprocess("messagepipe-pipe");
+                        .AddNamedPipeInterprocess("messagepipe-pipe");
                 })
                 .RunConsoleAppFrameworkAsync<Program>(args);
         }

--- a/sandbox/InterprocessServer/Program.cs
+++ b/sandbox/InterprocessServer/Program.cs
@@ -32,8 +32,8 @@ namespace InterprocessServer
             Host.CreateDefaultBuilder()
                 .ConfigureServices(x =>
                 {
-                    x.AddMessagePipe();
-                    x.AddMessagePipeNamedPipeInterprocess("messagepipe-pipe");
+                    x.AddMessagePipe()
+                        .AddMessagePipeNamedPipeInterprocess("messagepipe-pipe");
                 })
                 .RunConsoleAppFrameworkAsync<Program>(args);
         }

--- a/src/MessagePipe.Interprocess/ServiceCollectionInterprocessExtensions.cs
+++ b/src/MessagePipe.Interprocess/ServiceCollectionInterprocessExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using MessagePipe;
 using MessagePipe.Interprocess;
 using MessagePipe.Interprocess.Workers;
 #if !UNITY_2018_3_OR_NEWER
@@ -6,58 +7,58 @@ using Microsoft.Extensions.DependencyInjection;
 #endif
 
 #if !UNITY_2018_3_OR_NEWER
-using ReturnType = Microsoft.Extensions.DependencyInjection.IServiceCollection;
+using ReturnType = Microsoft.Extensions.DependencyInjection.IMessagePipeBuilder;
+namespace Microsoft.Extensions.DependencyInjection
 #else
 using ReturnType = MessagePipe.Interprocess.MessagePipeInterprocessOptions;
-#endif
-
 namespace MessagePipe
+#endif
 {
     public static class ServiceCollectionInterprocessExtensions
     {
-        public static ReturnType AddMessagePipeUdpInterprocess(this IServiceCollection services, string host, int port)
+        public static ReturnType AddMessagePipeUdpInterprocess(this IMessagePipeBuilder builder, string host, int port)
         {
-            return AddMessagePipeUdpInterprocess(services, host, port, _ => { });
+            return AddMessagePipeUdpInterprocess(builder, host, port, _ => { });
         }
 
-        public static ReturnType AddMessagePipeUdpInterprocess(this IServiceCollection services, string host, int port, Action<MessagePipeInterprocessUdpOptions> configure)
+        public static ReturnType AddMessagePipeUdpInterprocess(this IMessagePipeBuilder builder, string host, int port, Action<MessagePipeInterprocessUdpOptions> configure)
         {
             var options = new MessagePipeInterprocessUdpOptions(host, port);
             configure(options);
 
-            services.AddSingleton(options);
-            services.Add(typeof(UdpWorker), options.InstanceLifetime);
+            builder.Services.AddSingleton(options);
+            builder.Services.Add(typeof(UdpWorker), options.InstanceLifetime);
 
 #if !UNITY_2018_3_OR_NEWER
-            services.Add(typeof(IDistributedPublisher<,>), typeof(UdpDistributedPublisher<,>), options.InstanceLifetime);
-            services.Add(typeof(IDistributedSubscriber<,>), typeof(UdpDistributedSubscriber<,>), options.InstanceLifetime);
-            return services;
+            builder.Services.Add(typeof(IDistributedPublisher<,>), typeof(UdpDistributedPublisher<,>), options.InstanceLifetime);
+            builder.Services.Add(typeof(IDistributedSubscriber<,>), typeof(UdpDistributedSubscriber<,>), options.InstanceLifetime);
+            return builder;
 #else
-            AddAsyncMessageBroker<IInterprocessKey, IInterprocessValue>(services, options);
+            AddAsyncMessageBroker<IInterprocessKey, IInterprocessValue>(builder, options);
             return options;
 #endif
         }
 
-        public static ReturnType AddMessagePipeTcpInterprocess(this IServiceCollection services, string host, int port)
+        public static ReturnType AddMessagePipeTcpInterprocess(this IMessagePipeBuilder builder, string host, int port)
         {
-            return AddMessagePipeTcpInterprocess(services, host, port, _ => { });
+            return AddMessagePipeTcpInterprocess(builder, host, port, _ => { });
         }
 
-        public static ReturnType AddMessagePipeTcpInterprocess(this IServiceCollection services, string host, int port, Action<MessagePipeInterprocessTcpOptions> configure)
+        public static ReturnType AddMessagePipeTcpInterprocess(this IMessagePipeBuilder builder, string host, int port, Action<MessagePipeInterprocessTcpOptions> configure)
         {
             var options = new MessagePipeInterprocessTcpOptions(host, port);
             configure(options);
 
-            services.AddSingleton(options);
-            services.Add(typeof(TcpWorker), options.InstanceLifetime);
+            builder.Services.AddSingleton(options);
+            builder.Services.Add(typeof(TcpWorker), options.InstanceLifetime);
 
 #if !UNITY_2018_3_OR_NEWER
-            services.Add(typeof(IDistributedPublisher<,>), typeof(TcpDistributedPublisher<,>), options.InstanceLifetime);
-            services.Add(typeof(IDistributedSubscriber<,>), typeof(TcpDistributedSubscriber<,>), options.InstanceLifetime);
-            services.Add(typeof(IRemoteRequestHandler<,>), typeof(TcpRemoteRequestHandler<,>), options.InstanceLifetime);
-            return services;
+            builder.Services.Add(typeof(IDistributedPublisher<,>), typeof(TcpDistributedPublisher<,>), options.InstanceLifetime);
+            builder.Services.Add(typeof(IDistributedSubscriber<,>), typeof(TcpDistributedSubscriber<,>), options.InstanceLifetime);
+            builder.Services.Add(typeof(IRemoteRequestHandler<,>), typeof(TcpRemoteRequestHandler<,>), options.InstanceLifetime);
+            return builder;
 #else
-            AddAsyncMessageBroker<IInterprocessKey, IInterprocessValue>(services, options);
+            AddAsyncMessageBroker<IInterprocessKey, IInterprocessValue>(builder, options);
             return options;
 #endif
 
@@ -67,26 +68,26 @@ namespace MessagePipe
 
         // NamedPipe in Unity is slightly buggy so disable.
 
-        public static ReturnType AddMessagePipeNamedPipeInterprocess(this IServiceCollection services, string pipeName)
+        public static ReturnType AddMessagePipeNamedPipeInterprocess(this IMessagePipeBuilder builder, string pipeName)
         {
-            return AddMessagePipeNamedPipeInterprocess(services, pipeName, _ => { });
+            return AddMessagePipeNamedPipeInterprocess(builder, pipeName, _ => { });
         }
 
-        public static ReturnType AddMessagePipeNamedPipeInterprocess(this IServiceCollection services, string pipeName, Action<MessagePipeInterprocessNamedPipeOptions> configure)
+        public static ReturnType AddMessagePipeNamedPipeInterprocess(this IMessagePipeBuilder builder, string pipeName, Action<MessagePipeInterprocessNamedPipeOptions> configure)
         {
             var options = new MessagePipeInterprocessNamedPipeOptions(pipeName);
             configure(options);
 
-            services.AddSingleton(options);
-            services.Add(typeof(NamedPipeWorker), options.InstanceLifetime);
+            builder.Services.AddSingleton(options);
+            builder.Services.Add(typeof(NamedPipeWorker), options.InstanceLifetime);
 
 #if !UNITY_2018_3_OR_NEWER
-            services.Add(typeof(IDistributedPublisher<,>), typeof(NamedPipeDistributedPublisher<,>), InstanceLifetime.Singleton);
-            services.Add(typeof(IDistributedSubscriber<,>), typeof(NamedPipeDistributedSubscriber<,>), InstanceLifetime.Singleton);
-            services.Add(typeof(IRemoteRequestHandler<,>), typeof(NamedPipeRemoteRequestHandler<,>), options.InstanceLifetime);
-            return services;
+            builder.Services.Add(typeof(IDistributedPublisher<,>), typeof(NamedPipeDistributedPublisher<,>), InstanceLifetime.Singleton);
+            builder.Services.Add(typeof(IDistributedSubscriber<,>), typeof(NamedPipeDistributedSubscriber<,>), InstanceLifetime.Singleton);
+            builder.Services.Add(typeof(IRemoteRequestHandler<,>), typeof(NamedPipeRemoteRequestHandler<,>), options.InstanceLifetime);
+            return builder;
 #else
-            AddAsyncMessageBroker<IInterprocessKey, IInterprocessValue>(services, options);
+            AddAsyncMessageBroker<IInterprocessKey, IInterprocessValue>(builder, options);
             return options;
 #endif
         }
@@ -114,97 +115,97 @@ namespace MessagePipe
 
 #if UNITY_2018_3_OR_NEWER
 
-        static void AddAsyncMessageBroker<TKey,TMessage>(this IServiceCollection services, MessagePipeInterprocessOptions options)
+        static void AddAsyncMessageBroker<TKey,TMessage>(this IMessagePipeBuilder builder, MessagePipeInterprocessOptions options)
         {
-            services.Add(typeof(AsyncMessageBrokerCore<TKey, TMessage>), options.InstanceLifetime);
-            services.Add(typeof(IAsyncPublisher<TKey, TMessage>), typeof(AsyncMessageBroker<TKey, TMessage>), options.InstanceLifetime);
-            services.Add(typeof(IAsyncSubscriber<TKey, TMessage>), typeof(AsyncMessageBroker<TKey, TMessage>), options.InstanceLifetime);
+            builder.Services.Add(typeof(AsyncMessageBrokerCore<TKey, TMessage>), options.InstanceLifetime);
+            builder.Services.Add(typeof(IAsyncPublisher<TKey, TMessage>), typeof(AsyncMessageBroker<TKey, TMessage>), options.InstanceLifetime);
+            builder.Services.Add(typeof(IAsyncSubscriber<TKey, TMessage>), typeof(AsyncMessageBroker<TKey, TMessage>), options.InstanceLifetime);
         }
 
-        public static IServiceCollection RegisterUpdInterprocessMessageBroker<TKey, TMessage>(this IServiceCollection services, MessagePipeInterprocessOptions options)
+        public static IMessagePipeBuilder RegisterUpdInterprocessMessageBroker<TKey, TMessage>(this IMessagePipeBuilder builder, MessagePipeInterprocessOptions options)
         {
-            AddAsyncMessageBroker<TKey, TMessage>(services, options);
-            services.Add(typeof(IDistributedPublisher<TKey, TMessage>), typeof(UdpDistributedPublisher<TKey, TMessage>), options.InstanceLifetime);
-            services.Add(typeof(IDistributedSubscriber<TKey, TMessage>), typeof(UdpDistributedSubscriber<TKey, TMessage>), options.InstanceLifetime);
+            AddAsyncMessageBroker<TKey, TMessage>(builder, options);
+            builder.Services.Add(typeof(IDistributedPublisher<TKey, TMessage>), typeof(UdpDistributedPublisher<TKey, TMessage>), options.InstanceLifetime);
+            builder.Services.Add(typeof(IDistributedSubscriber<TKey, TMessage>), typeof(UdpDistributedSubscriber<TKey, TMessage>), options.InstanceLifetime);
 
-            return services;
+            return builder;
         }
 
-        public static IServiceCollection RegisterTcpInterprocessMessageBroker<TKey, TMessage>(this IServiceCollection services, MessagePipeInterprocessOptions options)
+        public static IMessagePipeBuilder RegisterTcpInterprocessMessageBroker<TKey, TMessage>(this IMessagePipeBuilder builder, MessagePipeInterprocessOptions options)
         {
-            AddAsyncMessageBroker<TKey, TMessage>(services, options);
-            services.Add(typeof(IDistributedPublisher<TKey, TMessage>), typeof(TcpDistributedPublisher<TKey, TMessage>), options.InstanceLifetime);
-            services.Add(typeof(IDistributedSubscriber<TKey, TMessage>), typeof(TcpDistributedSubscriber<TKey, TMessage>), options.InstanceLifetime);
+            AddAsyncMessageBroker<TKey, TMessage>(builder, options);
+            builder.Services.Add(typeof(IDistributedPublisher<TKey, TMessage>), typeof(TcpDistributedPublisher<TKey, TMessage>), options.InstanceLifetime);
+            builder.Services.Add(typeof(IDistributedSubscriber<TKey, TMessage>), typeof(TcpDistributedSubscriber<TKey, TMessage>), options.InstanceLifetime);
 
-            return services;
+            return builder;
         }
 
-        //public static IServiceCollection RegisterNamedPipeInterprocessMessageBroker<TKey, TMessage>(this IServiceCollection services, MessagePipeInterprocessOptions options)
+        //public static IMessagePipeBuilder RegisterNamedPipeInterprocessMessageBroker<TKey, TMessage>(this IMessagePipeBuilder builder, MessagePipeInterprocessOptions options)
         //{
-        //    AddAsyncMessageBroker<TKey, TMessage>(services, options);
-        //    services.Add(typeof(IDistributedPublisher<TKey, TMessage>), typeof(NamedPipeDistributedPublisher<TKey, TMessage>), options.InstanceLifetime);
-        //    services.Add(typeof(IDistributedSubscriber<TKey, TMessage>), typeof(NamedPipeDistributedSubscriber<TKey, TMessage>), options.InstanceLifetime);
+        //    AddAsyncMessageBroker<TKey, TMessage>(builder, options);
+        //    builder.Services.Add(typeof(IDistributedPublisher<TKey, TMessage>), typeof(NamedPipeDistributedPublisher<TKey, TMessage>), options.InstanceLifetime);
+        //    builder.Services.Add(typeof(IDistributedSubscriber<TKey, TMessage>), typeof(NamedPipeDistributedSubscriber<TKey, TMessage>), options.InstanceLifetime);
 
-        //    return services;
+        //    return builder;
         //}
 
-        public static IServiceCollection RegisterTcpRemoteRequestHandler<TRequest, TResponse>(this IServiceCollection services, MessagePipeInterprocessOptions options)
+        public static IMessagePipeBuilder RegisterTcpRemoteRequestHandler<TRequest, TResponse>(this IMessagePipeBuilder builder, MessagePipeInterprocessOptions options)
         {
-            services.Add(typeof(IRemoteRequestHandler<TRequest, TResponse>), typeof(TcpRemoteRequestHandler<TRequest, TResponse>), options.InstanceLifetime);
+            builder.Services.Add(typeof(IRemoteRequestHandler<TRequest, TResponse>), typeof(TcpRemoteRequestHandler<TRequest, TResponse>), options.InstanceLifetime);
 
-            return services;
+            return builder;
         }
 
-        //public static IServiceCollection RegisterNamedPipeRemoteRequestHandler<TRequest, TResponse>(this IServiceCollection services, MessagePipeInterprocessOptions options)
+        //public static IMessagePipeBuilder RegisterNamedPipeRemoteRequestHandler<TRequest, TResponse>(this IMessagePipeBuilder builder, MessagePipeInterprocessOptions options)
         //{
-        //    services.Add(typeof(IRemoteRequestHandler<TRequest, TResponse>), typeof(NamedPipeRemoteRequestHandler<TRequest, TResponse>), options.InstanceLifetime);
+        //    builder.Services.Add(typeof(IRemoteRequestHandler<TRequest, TResponse>), typeof(NamedPipeRemoteRequestHandler<TRequest, TResponse>), options.InstanceLifetime);
 
-        //    return services;
+        //    return builder;
         //}
 
 #endif
 #if NET5_0_OR_GREATER
-        public static ReturnType AddMessagePipeUdpInterprocessUds(this IServiceCollection services, string domainSocketPath)
+        public static ReturnType AddMessagePipeUdpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath)
         {
-            return AddMessagePipeUdpInterprocessUds(services, domainSocketPath, _ => { });
+            return AddMessagePipeUdpInterprocessUds(builder, domainSocketPath, _ => { });
         }
-        public static ReturnType AddMessagePipeUdpInterprocessUds(this IServiceCollection services, string domainSocketPath, Action<MessagePipeInterprocessUdpUdsOptions> configure)
+        public static ReturnType AddMessagePipeUdpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath, Action<MessagePipeInterprocessUdpUdsOptions> configure)
         {
             var options = new MessagePipeInterprocessUdpUdsOptions(domainSocketPath);
             configure(options);
 
-            services.AddSingleton(options);
-            services.Add(typeof(UdpWorker), options.InstanceLifetime);
+            builder.Services.AddSingleton(options);
+            builder.Services.Add(typeof(UdpWorker), options.InstanceLifetime);
 
 #if !UNITY_2018_3_OR_NEWER
-            services.Add(typeof(IDistributedPublisher<,>), typeof(UdpDistributedPublisher<,>), options.InstanceLifetime);
-            services.Add(typeof(IDistributedSubscriber<,>), typeof(UdpDistributedSubscriber<,>), options.InstanceLifetime);
-            return services;
+            builder.Services.Add(typeof(IDistributedPublisher<,>), typeof(UdpDistributedPublisher<,>), options.InstanceLifetime);
+            builder.Services.Add(typeof(IDistributedSubscriber<,>), typeof(UdpDistributedSubscriber<,>), options.InstanceLifetime);
+            return builder;
 #else
-            AddAsyncMessageBroker<IInterprocessKey, IInterprocessValue>(services, options);
+            AddAsyncMessageBroker<IInterprocessKey, IInterprocessValue>(builder, options);
             return options;
 #endif
         }
-        public static ReturnType AddMessagePipeTcpInterprocessUds(this IServiceCollection services, string domainSocketPath)
+        public static ReturnType AddMessagePipeTcpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath)
         {
-            return AddMessagePipeTcpInterprocessUds(services, domainSocketPath, _ => { });
+            return AddMessagePipeTcpInterprocessUds(builder, domainSocketPath, _ => { });
         }
 
-        public static ReturnType AddMessagePipeTcpInterprocessUds(this IServiceCollection services, string domainSocketPath, Action<MessagePipeInterprocessTcpUdsOptions> configure)
+        public static ReturnType AddMessagePipeTcpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath, Action<MessagePipeInterprocessTcpUdsOptions> configure)
         {
             var options = new MessagePipeInterprocessTcpUdsOptions(domainSocketPath);
             configure(options);
 
-            services.AddSingleton(options);
-            services.Add(typeof(TcpWorker), options.InstanceLifetime);
+            builder.Services.AddSingleton(options);
+            builder.Services.Add(typeof(TcpWorker), options.InstanceLifetime);
 
 #if !UNITY_2018_3_OR_NEWER
-            services.Add(typeof(IDistributedPublisher<,>), typeof(TcpDistributedPublisher<,>), options.InstanceLifetime);
-            services.Add(typeof(IDistributedSubscriber<,>), typeof(TcpDistributedSubscriber<,>), options.InstanceLifetime);
-            services.Add(typeof(IRemoteRequestHandler<,>), typeof(TcpRemoteRequestHandler<,>), options.InstanceLifetime);
-            return services;
+            builder.Services.Add(typeof(IDistributedPublisher<,>), typeof(TcpDistributedPublisher<,>), options.InstanceLifetime);
+            builder.Services.Add(typeof(IDistributedSubscriber<,>), typeof(TcpDistributedSubscriber<,>), options.InstanceLifetime);
+            builder.Services.Add(typeof(IRemoteRequestHandler<,>), typeof(TcpRemoteRequestHandler<,>), options.InstanceLifetime);
+            return builder;
 #else
-            AddAsyncMessageBroker<IInterprocessKey, IInterprocessValue>(services, options);
+            AddAsyncMessageBroker<IInterprocessKey, IInterprocessValue>(builder, options);
             return options;
 #endif
 

--- a/src/MessagePipe.Interprocess/ServiceCollectionInterprocessExtensions.cs
+++ b/src/MessagePipe.Interprocess/ServiceCollectionInterprocessExtensions.cs
@@ -16,12 +16,12 @@ namespace MessagePipe
 {
     public static class ServiceCollectionInterprocessExtensions
     {
-        public static ReturnType AddMessagePipeUdpInterprocess(this IMessagePipeBuilder builder, string host, int port)
+        public static ReturnType AddUdpInterprocess(this IMessagePipeBuilder builder, string host, int port)
         {
-            return AddMessagePipeUdpInterprocess(builder, host, port, _ => { });
+            return AddUdpInterprocess(builder, host, port, _ => { });
         }
 
-        public static ReturnType AddMessagePipeUdpInterprocess(this IMessagePipeBuilder builder, string host, int port, Action<MessagePipeInterprocessUdpOptions> configure)
+        public static ReturnType AddUdpInterprocess(this IMessagePipeBuilder builder, string host, int port, Action<MessagePipeInterprocessUdpOptions> configure)
         {
             var options = new MessagePipeInterprocessUdpOptions(host, port);
             configure(options);
@@ -39,12 +39,12 @@ namespace MessagePipe
 #endif
         }
 
-        public static ReturnType AddMessagePipeTcpInterprocess(this IMessagePipeBuilder builder, string host, int port)
+        public static ReturnType AddTcpInterprocess(this IMessagePipeBuilder builder, string host, int port)
         {
-            return AddMessagePipeTcpInterprocess(builder, host, port, _ => { });
+            return AddTcpInterprocess(builder, host, port, _ => { });
         }
 
-        public static ReturnType AddMessagePipeTcpInterprocess(this IMessagePipeBuilder builder, string host, int port, Action<MessagePipeInterprocessTcpOptions> configure)
+        public static ReturnType AddTcpInterprocess(this IMessagePipeBuilder builder, string host, int port, Action<MessagePipeInterprocessTcpOptions> configure)
         {
             var options = new MessagePipeInterprocessTcpOptions(host, port);
             configure(options);
@@ -68,12 +68,12 @@ namespace MessagePipe
 
         // NamedPipe in Unity is slightly buggy so disable.
 
-        public static ReturnType AddMessagePipeNamedPipeInterprocess(this IMessagePipeBuilder builder, string pipeName)
+        public static ReturnType AddNamedPipeInterprocess(this IMessagePipeBuilder builder, string pipeName)
         {
-            return AddMessagePipeNamedPipeInterprocess(builder, pipeName, _ => { });
+            return AddNamedPipeInterprocess(builder, pipeName, _ => { });
         }
 
-        public static ReturnType AddMessagePipeNamedPipeInterprocess(this IMessagePipeBuilder builder, string pipeName, Action<MessagePipeInterprocessNamedPipeOptions> configure)
+        public static ReturnType AddNamedPipeInterprocess(this IMessagePipeBuilder builder, string pipeName, Action<MessagePipeInterprocessNamedPipeOptions> configure)
         {
             var options = new MessagePipeInterprocessNamedPipeOptions(pipeName);
             configure(options);
@@ -165,11 +165,11 @@ namespace MessagePipe
 
 #endif
 #if NET5_0_OR_GREATER
-        public static ReturnType AddMessagePipeUdpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath)
+        public static ReturnType AddUdpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath)
         {
-            return AddMessagePipeUdpInterprocessUds(builder, domainSocketPath, _ => { });
+            return AddUdpInterprocessUds(builder, domainSocketPath, _ => { });
         }
-        public static ReturnType AddMessagePipeUdpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath, Action<MessagePipeInterprocessUdpUdsOptions> configure)
+        public static ReturnType AddUdpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath, Action<MessagePipeInterprocessUdpUdsOptions> configure)
         {
             var options = new MessagePipeInterprocessUdpUdsOptions(domainSocketPath);
             configure(options);
@@ -186,12 +186,12 @@ namespace MessagePipe
             return options;
 #endif
         }
-        public static ReturnType AddMessagePipeTcpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath)
+        public static ReturnType AddTcpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath)
         {
-            return AddMessagePipeTcpInterprocessUds(builder, domainSocketPath, _ => { });
+            return AddTcpInterprocessUds(builder, domainSocketPath, _ => { });
         }
 
-        public static ReturnType AddMessagePipeTcpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath, Action<MessagePipeInterprocessTcpUdsOptions> configure)
+        public static ReturnType AddTcpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath, Action<MessagePipeInterprocessTcpUdsOptions> configure)
         {
             var options = new MessagePipeInterprocessTcpUdsOptions(domainSocketPath);
             configure(options);

--- a/src/MessagePipe.Nats/ServiceCollectionNatsExtensions.cs
+++ b/src/MessagePipe.Nats/ServiceCollectionNatsExtensions.cs
@@ -1,25 +1,27 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿
+using MessagePipe;
+using MessagePipe.Nats;
 
-namespace MessagePipe.Nats;
+namespace Microsoft.Extensions.DependencyInjection;
 
 public static class ServiceCollectionNatsExtensions
 {
-    public static IServiceCollection AddMessagePipeNats(this IServiceCollection services, NatsConnectionFactory connectionFactory)
+    public static IMessagePipeBuilder AddMessagePipeNats(this IMessagePipeBuilder builder, NatsConnectionFactory connectionFactory)
     {
-        return AddMessagePipeNats(services, connectionFactory, _ => { });
+        return AddMessagePipeNats(builder, connectionFactory, _ => { });
     }
 
-    public static IServiceCollection AddMessagePipeNats(this IServiceCollection services, NatsConnectionFactory connectionFactory, Action<MessagePipeNatsOptions> configure)
+    public static IMessagePipeBuilder AddMessagePipeNats(this IMessagePipeBuilder builder, NatsConnectionFactory connectionFactory, Action<MessagePipeNatsOptions> configure)
     {
         var options = new MessagePipeNatsOptions(connectionFactory);
         configure(options);
-        services.AddSingleton(options);
-        services.AddSingleton(options.NatsConnectionFactory);
+        builder.Services.AddSingleton(options);
+        builder.Services.AddSingleton(options.NatsConnectionFactory);
 
-        services.Add(typeof(IDistributedPublisher<,>), typeof(NatsPublisher<,>), InstanceLifetime.Singleton);
-        services.Add(typeof(IDistributedSubscriber<,>), typeof(NatsSubscriber<,>), InstanceLifetime.Singleton);
+        builder.Services.Add(typeof(IDistributedPublisher<,>), typeof(NatsPublisher<,>), InstanceLifetime.Singleton);
+        builder.Services.Add(typeof(IDistributedSubscriber<,>), typeof(NatsSubscriber<,>), InstanceLifetime.Singleton);
 
-        return services;
+        return builder;
     }
 
     static void Add(this IServiceCollection services, Type serviceType, Type implementationType, InstanceLifetime scope)

--- a/src/MessagePipe.Nats/ServiceCollectionNatsExtensions.cs
+++ b/src/MessagePipe.Nats/ServiceCollectionNatsExtensions.cs
@@ -6,12 +6,12 @@ namespace Microsoft.Extensions.DependencyInjection;
 
 public static class ServiceCollectionNatsExtensions
 {
-    public static IMessagePipeBuilder AddMessagePipeNats(this IMessagePipeBuilder builder, NatsConnectionFactory connectionFactory)
+    public static IMessagePipeBuilder AddNats(this IMessagePipeBuilder builder, NatsConnectionFactory connectionFactory)
     {
-        return AddMessagePipeNats(builder, connectionFactory, _ => { });
+        return AddNats(builder, connectionFactory, _ => { });
     }
 
-    public static IMessagePipeBuilder AddMessagePipeNats(this IMessagePipeBuilder builder, NatsConnectionFactory connectionFactory, Action<MessagePipeNatsOptions> configure)
+    public static IMessagePipeBuilder AddNats(this IMessagePipeBuilder builder, NatsConnectionFactory connectionFactory, Action<MessagePipeNatsOptions> configure)
     {
         var options = new MessagePipeNatsOptions(connectionFactory);
         configure(options);

--- a/src/MessagePipe.Redis/ServiceCollectionRedisExtensions.cs
+++ b/src/MessagePipe.Redis/ServiceCollectionRedisExtensions.cs
@@ -1,42 +1,41 @@
 ﻿using MessagePipe;
 using MessagePipe.Redis;
-using Microsoft.Extensions.DependencyInjection;
 using StackExchange.Redis;
 using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace MessagePipe
+namespace Microsoft.Extensions.DependencyInjection
 {
     public static class ServiceCollectionRedisExtensions
     {
-        public static IServiceCollection AddMessagePipeRedis(this IServiceCollection services, IConnectionMultiplexer connectionMultiplexer)
+        public static IMessagePipeBuilder AddMessagePipeRedis(this IMessagePipeBuilder builder, IConnectionMultiplexer connectionMultiplexer)
         {
-            return AddMessagePipeRedis(services, new SingleConnectionMultiplexerFactory(connectionMultiplexer), _ => { });
+            return AddMessagePipeRedis(builder, new SingleConnectionMultiplexerFactory(connectionMultiplexer), _ => { });
         }
 
-        public static IServiceCollection AddMessagePipeRedis(this IServiceCollection services, IConnectionMultiplexerFactory connectionMultiplexerFactory)
+        public static IMessagePipeBuilder AddMessagePipeRedis(this IMessagePipeBuilder builder, IConnectionMultiplexerFactory connectionMultiplexerFactory)
         {
-            return AddMessagePipeRedis(services, connectionMultiplexerFactory, _ => { });
+            return AddMessagePipeRedis(builder, connectionMultiplexerFactory, _ => { });
         }
 
-        public static IServiceCollection AddMessagePipeRedis(this IServiceCollection services, IConnectionMultiplexer connectionMultiplexer, Action<MessagePipeRedisOptions> configure)
+        public static IMessagePipeBuilder AddMessagePipeRedis(this IMessagePipeBuilder builder, IConnectionMultiplexer connectionMultiplexer, Action<MessagePipeRedisOptions> configure)
         {
-            return AddMessagePipeRedis(services, new SingleConnectionMultiplexerFactory(connectionMultiplexer), configure);
+            return AddMessagePipeRedis(builder, new SingleConnectionMultiplexerFactory(connectionMultiplexer), configure);
         }
 
-        public static IServiceCollection AddMessagePipeRedis(this IServiceCollection services, IConnectionMultiplexerFactory connectionMultiplexerFactory, Action<MessagePipeRedisOptions> configure)
+        public static IMessagePipeBuilder AddMessagePipeRedis(this IMessagePipeBuilder builder, IConnectionMultiplexerFactory connectionMultiplexerFactory, Action<MessagePipeRedisOptions> configure)
         {
             var options = new MessagePipeRedisOptions(connectionMultiplexerFactory);
             configure(options);
-            services.AddSingleton(options); // add as singleton instance
-            services.AddSingleton<IConnectionMultiplexerFactory>(options.ConnectionMultiplexerFactory);
-            services.AddSingleton<IRedisSerializer>(options.RedisSerializer);
+            builder.Services.AddSingleton(options); // add as singleton instance
+            builder.Services.AddSingleton<IConnectionMultiplexerFactory>(options.ConnectionMultiplexerFactory);
+            builder.Services.AddSingleton<IRedisSerializer>(options.RedisSerializer);
 
-            services.Add(typeof(IDistributedPublisher<,>), typeof(RedisPublisher<,>), InstanceLifetime.Singleton);
-            services.Add(typeof(IDistributedSubscriber<,>), typeof(RedisSubscriber<,>), InstanceLifetime.Singleton);
+            builder.Services.Add(typeof(IDistributedPublisher<,>), typeof(RedisPublisher<,>), InstanceLifetime.Singleton);
+            builder.Services.Add(typeof(IDistributedSubscriber<,>), typeof(RedisSubscriber<,>), InstanceLifetime.Singleton);
 
-            return services;
+            return builder;
         }
 
         static void Add(this IServiceCollection services, Type serviceType, Type implementationType, InstanceLifetime scope)

--- a/src/MessagePipe.Redis/ServiceCollectionRedisExtensions.cs
+++ b/src/MessagePipe.Redis/ServiceCollectionRedisExtensions.cs
@@ -9,22 +9,22 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class ServiceCollectionRedisExtensions
     {
-        public static IMessagePipeBuilder AddMessagePipeRedis(this IMessagePipeBuilder builder, IConnectionMultiplexer connectionMultiplexer)
+        public static IMessagePipeBuilder AddRedis(this IMessagePipeBuilder builder, IConnectionMultiplexer connectionMultiplexer)
         {
-            return AddMessagePipeRedis(builder, new SingleConnectionMultiplexerFactory(connectionMultiplexer), _ => { });
+            return AddRedis(builder, new SingleConnectionMultiplexerFactory(connectionMultiplexer), _ => { });
         }
 
-        public static IMessagePipeBuilder AddMessagePipeRedis(this IMessagePipeBuilder builder, IConnectionMultiplexerFactory connectionMultiplexerFactory)
+        public static IMessagePipeBuilder AddRedis(this IMessagePipeBuilder builder, IConnectionMultiplexerFactory connectionMultiplexerFactory)
         {
-            return AddMessagePipeRedis(builder, connectionMultiplexerFactory, _ => { });
+            return AddRedis(builder, connectionMultiplexerFactory, _ => { });
         }
 
-        public static IMessagePipeBuilder AddMessagePipeRedis(this IMessagePipeBuilder builder, IConnectionMultiplexer connectionMultiplexer, Action<MessagePipeRedisOptions> configure)
+        public static IMessagePipeBuilder AddRedis(this IMessagePipeBuilder builder, IConnectionMultiplexer connectionMultiplexer, Action<MessagePipeRedisOptions> configure)
         {
-            return AddMessagePipeRedis(builder, new SingleConnectionMultiplexerFactory(connectionMultiplexer), configure);
+            return AddRedis(builder, new SingleConnectionMultiplexerFactory(connectionMultiplexer), configure);
         }
 
-        public static IMessagePipeBuilder AddMessagePipeRedis(this IMessagePipeBuilder builder, IConnectionMultiplexerFactory connectionMultiplexerFactory, Action<MessagePipeRedisOptions> configure)
+        public static IMessagePipeBuilder AddRedis(this IMessagePipeBuilder builder, IConnectionMultiplexerFactory connectionMultiplexerFactory, Action<MessagePipeRedisOptions> configure)
         {
             var options = new MessagePipeRedisOptions(connectionMultiplexerFactory);
             configure(options);

--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Interprocess/Runtime/ServiceCollectionInterprocessExtensions.cs
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Interprocess/Runtime/ServiceCollectionInterprocessExtensions.cs
@@ -16,12 +16,12 @@ namespace MessagePipe
 {
     public static class ServiceCollectionInterprocessExtensions
     {
-        public static ReturnType AddMessagePipeUdpInterprocess(this IMessagePipeBuilder builder, string host, int port)
+        public static ReturnType AddUdpInterprocess(this IMessagePipeBuilder builder, string host, int port)
         {
-            return AddMessagePipeUdpInterprocess(builder, host, port, _ => { });
+            return AddUdpInterprocess(builder, host, port, _ => { });
         }
 
-        public static ReturnType AddMessagePipeUdpInterprocess(this IMessagePipeBuilder builder, string host, int port, Action<MessagePipeInterprocessUdpOptions> configure)
+        public static ReturnType AddUdpInterprocess(this IMessagePipeBuilder builder, string host, int port, Action<MessagePipeInterprocessUdpOptions> configure)
         {
             var options = new MessagePipeInterprocessUdpOptions(host, port);
             configure(options);
@@ -39,12 +39,12 @@ namespace MessagePipe
 #endif
         }
 
-        public static ReturnType AddMessagePipeTcpInterprocess(this IMessagePipeBuilder builder, string host, int port)
+        public static ReturnType AddTcpInterprocess(this IMessagePipeBuilder builder, string host, int port)
         {
-            return AddMessagePipeTcpInterprocess(builder, host, port, _ => { });
+            return AddTcpInterprocess(builder, host, port, _ => { });
         }
 
-        public static ReturnType AddMessagePipeTcpInterprocess(this IMessagePipeBuilder builder, string host, int port, Action<MessagePipeInterprocessTcpOptions> configure)
+        public static ReturnType AddTcpInterprocess(this IMessagePipeBuilder builder, string host, int port, Action<MessagePipeInterprocessTcpOptions> configure)
         {
             var options = new MessagePipeInterprocessTcpOptions(host, port);
             configure(options);
@@ -68,12 +68,12 @@ namespace MessagePipe
 
         // NamedPipe in Unity is slightly buggy so disable.
 
-        public static ReturnType AddMessagePipeNamedPipeInterprocess(this IMessagePipeBuilder builder, string pipeName)
+        public static ReturnType AddNamedPipeInterprocess(this IMessagePipeBuilder builder, string pipeName)
         {
-            return AddMessagePipeNamedPipeInterprocess(builder, pipeName, _ => { });
+            return AddNamedPipeInterprocess(builder, pipeName, _ => { });
         }
 
-        public static ReturnType AddMessagePipeNamedPipeInterprocess(this IMessagePipeBuilder builder, string pipeName, Action<MessagePipeInterprocessNamedPipeOptions> configure)
+        public static ReturnType AddNamedPipeInterprocess(this IMessagePipeBuilder builder, string pipeName, Action<MessagePipeInterprocessNamedPipeOptions> configure)
         {
             var options = new MessagePipeInterprocessNamedPipeOptions(pipeName);
             configure(options);
@@ -165,11 +165,11 @@ namespace MessagePipe
 
 #endif
 #if NET5_0_OR_GREATER
-        public static ReturnType AddMessagePipeUdpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath)
+        public static ReturnType AddUdpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath)
         {
-            return AddMessagePipeUdpInterprocessUds(builder, domainSocketPath, _ => { });
+            return AddUdpInterprocessUds(builder, domainSocketPath, _ => { });
         }
-        public static ReturnType AddMessagePipeUdpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath, Action<MessagePipeInterprocessUdpUdsOptions> configure)
+        public static ReturnType AddUdpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath, Action<MessagePipeInterprocessUdpUdsOptions> configure)
         {
             var options = new MessagePipeInterprocessUdpUdsOptions(domainSocketPath);
             configure(options);
@@ -186,12 +186,12 @@ namespace MessagePipe
             return options;
 #endif
         }
-        public static ReturnType AddMessagePipeTcpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath)
+        public static ReturnType AddTcpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath)
         {
-            return AddMessagePipeTcpInterprocessUds(builder, domainSocketPath, _ => { });
+            return AddTcpInterprocessUds(builder, domainSocketPath, _ => { });
         }
 
-        public static ReturnType AddMessagePipeTcpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath, Action<MessagePipeInterprocessTcpUdsOptions> configure)
+        public static ReturnType AddTcpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath, Action<MessagePipeInterprocessTcpUdsOptions> configure)
         {
             var options = new MessagePipeInterprocessTcpUdsOptions(domainSocketPath);
             configure(options);

--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Interprocess/Runtime/ServiceCollectionInterprocessExtensions.cs
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.Interprocess/Runtime/ServiceCollectionInterprocessExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using MessagePipe;
 using MessagePipe.Interprocess;
 using MessagePipe.Interprocess.Workers;
 #if !UNITY_2018_3_OR_NEWER
@@ -6,58 +7,58 @@ using Microsoft.Extensions.DependencyInjection;
 #endif
 
 #if !UNITY_2018_3_OR_NEWER
-using ReturnType = Microsoft.Extensions.DependencyInjection.IServiceCollection;
+using ReturnType = Microsoft.Extensions.DependencyInjection.IMessagePipeBuilder;
+namespace Microsoft.Extensions.DependencyInjection
 #else
 using ReturnType = MessagePipe.Interprocess.MessagePipeInterprocessOptions;
-#endif
-
 namespace MessagePipe
+#endif
 {
     public static class ServiceCollectionInterprocessExtensions
     {
-        public static ReturnType AddMessagePipeUdpInterprocess(this IServiceCollection services, string host, int port)
+        public static ReturnType AddMessagePipeUdpInterprocess(this IMessagePipeBuilder builder, string host, int port)
         {
-            return AddMessagePipeUdpInterprocess(services, host, port, _ => { });
+            return AddMessagePipeUdpInterprocess(builder, host, port, _ => { });
         }
 
-        public static ReturnType AddMessagePipeUdpInterprocess(this IServiceCollection services, string host, int port, Action<MessagePipeInterprocessUdpOptions> configure)
+        public static ReturnType AddMessagePipeUdpInterprocess(this IMessagePipeBuilder builder, string host, int port, Action<MessagePipeInterprocessUdpOptions> configure)
         {
             var options = new MessagePipeInterprocessUdpOptions(host, port);
             configure(options);
 
-            services.AddSingleton(options);
-            services.Add(typeof(UdpWorker), options.InstanceLifetime);
+            builder.Services.AddSingleton(options);
+            builder.Services.Add(typeof(UdpWorker), options.InstanceLifetime);
 
 #if !UNITY_2018_3_OR_NEWER
-            services.Add(typeof(IDistributedPublisher<,>), typeof(UdpDistributedPublisher<,>), options.InstanceLifetime);
-            services.Add(typeof(IDistributedSubscriber<,>), typeof(UdpDistributedSubscriber<,>), options.InstanceLifetime);
-            return services;
+            builder.Services.Add(typeof(IDistributedPublisher<,>), typeof(UdpDistributedPublisher<,>), options.InstanceLifetime);
+            builder.Services.Add(typeof(IDistributedSubscriber<,>), typeof(UdpDistributedSubscriber<,>), options.InstanceLifetime);
+            return builder;
 #else
-            AddAsyncMessageBroker<IInterprocessKey, IInterprocessValue>(services, options);
+            AddAsyncMessageBroker<IInterprocessKey, IInterprocessValue>(builder, options);
             return options;
 #endif
         }
 
-        public static ReturnType AddMessagePipeTcpInterprocess(this IServiceCollection services, string host, int port)
+        public static ReturnType AddMessagePipeTcpInterprocess(this IMessagePipeBuilder builder, string host, int port)
         {
-            return AddMessagePipeTcpInterprocess(services, host, port, _ => { });
+            return AddMessagePipeTcpInterprocess(builder, host, port, _ => { });
         }
 
-        public static ReturnType AddMessagePipeTcpInterprocess(this IServiceCollection services, string host, int port, Action<MessagePipeInterprocessTcpOptions> configure)
+        public static ReturnType AddMessagePipeTcpInterprocess(this IMessagePipeBuilder builder, string host, int port, Action<MessagePipeInterprocessTcpOptions> configure)
         {
             var options = new MessagePipeInterprocessTcpOptions(host, port);
             configure(options);
 
-            services.AddSingleton(options);
-            services.Add(typeof(TcpWorker), options.InstanceLifetime);
+            builder.Services.AddSingleton(options);
+            builder.Services.Add(typeof(TcpWorker), options.InstanceLifetime);
 
 #if !UNITY_2018_3_OR_NEWER
-            services.Add(typeof(IDistributedPublisher<,>), typeof(TcpDistributedPublisher<,>), options.InstanceLifetime);
-            services.Add(typeof(IDistributedSubscriber<,>), typeof(TcpDistributedSubscriber<,>), options.InstanceLifetime);
-            services.Add(typeof(IRemoteRequestHandler<,>), typeof(TcpRemoteRequestHandler<,>), options.InstanceLifetime);
-            return services;
+            builder.Services.Add(typeof(IDistributedPublisher<,>), typeof(TcpDistributedPublisher<,>), options.InstanceLifetime);
+            builder.Services.Add(typeof(IDistributedSubscriber<,>), typeof(TcpDistributedSubscriber<,>), options.InstanceLifetime);
+            builder.Services.Add(typeof(IRemoteRequestHandler<,>), typeof(TcpRemoteRequestHandler<,>), options.InstanceLifetime);
+            return builder;
 #else
-            AddAsyncMessageBroker<IInterprocessKey, IInterprocessValue>(services, options);
+            AddAsyncMessageBroker<IInterprocessKey, IInterprocessValue>(builder, options);
             return options;
 #endif
 
@@ -67,26 +68,26 @@ namespace MessagePipe
 
         // NamedPipe in Unity is slightly buggy so disable.
 
-        public static ReturnType AddMessagePipeNamedPipeInterprocess(this IServiceCollection services, string pipeName)
+        public static ReturnType AddMessagePipeNamedPipeInterprocess(this IMessagePipeBuilder builder, string pipeName)
         {
-            return AddMessagePipeNamedPipeInterprocess(services, pipeName, _ => { });
+            return AddMessagePipeNamedPipeInterprocess(builder, pipeName, _ => { });
         }
 
-        public static ReturnType AddMessagePipeNamedPipeInterprocess(this IServiceCollection services, string pipeName, Action<MessagePipeInterprocessNamedPipeOptions> configure)
+        public static ReturnType AddMessagePipeNamedPipeInterprocess(this IMessagePipeBuilder builder, string pipeName, Action<MessagePipeInterprocessNamedPipeOptions> configure)
         {
             var options = new MessagePipeInterprocessNamedPipeOptions(pipeName);
             configure(options);
 
-            services.AddSingleton(options);
-            services.Add(typeof(NamedPipeWorker), options.InstanceLifetime);
+            builder.Services.AddSingleton(options);
+            builder.Services.Add(typeof(NamedPipeWorker), options.InstanceLifetime);
 
 #if !UNITY_2018_3_OR_NEWER
-            services.Add(typeof(IDistributedPublisher<,>), typeof(NamedPipeDistributedPublisher<,>), InstanceLifetime.Singleton);
-            services.Add(typeof(IDistributedSubscriber<,>), typeof(NamedPipeDistributedSubscriber<,>), InstanceLifetime.Singleton);
-            services.Add(typeof(IRemoteRequestHandler<,>), typeof(NamedPipeRemoteRequestHandler<,>), options.InstanceLifetime);
-            return services;
+            builder.Services.Add(typeof(IDistributedPublisher<,>), typeof(NamedPipeDistributedPublisher<,>), InstanceLifetime.Singleton);
+            builder.Services.Add(typeof(IDistributedSubscriber<,>), typeof(NamedPipeDistributedSubscriber<,>), InstanceLifetime.Singleton);
+            builder.Services.Add(typeof(IRemoteRequestHandler<,>), typeof(NamedPipeRemoteRequestHandler<,>), options.InstanceLifetime);
+            return builder;
 #else
-            AddAsyncMessageBroker<IInterprocessKey, IInterprocessValue>(services, options);
+            AddAsyncMessageBroker<IInterprocessKey, IInterprocessValue>(builder, options);
             return options;
 #endif
         }
@@ -114,97 +115,97 @@ namespace MessagePipe
 
 #if UNITY_2018_3_OR_NEWER
 
-        static void AddAsyncMessageBroker<TKey,TMessage>(this IServiceCollection services, MessagePipeInterprocessOptions options)
+        static void AddAsyncMessageBroker<TKey,TMessage>(this IMessagePipeBuilder builder, MessagePipeInterprocessOptions options)
         {
-            services.Add(typeof(AsyncMessageBrokerCore<TKey, TMessage>), options.InstanceLifetime);
-            services.Add(typeof(IAsyncPublisher<TKey, TMessage>), typeof(AsyncMessageBroker<TKey, TMessage>), options.InstanceLifetime);
-            services.Add(typeof(IAsyncSubscriber<TKey, TMessage>), typeof(AsyncMessageBroker<TKey, TMessage>), options.InstanceLifetime);
+            builder.Services.Add(typeof(AsyncMessageBrokerCore<TKey, TMessage>), options.InstanceLifetime);
+            builder.Services.Add(typeof(IAsyncPublisher<TKey, TMessage>), typeof(AsyncMessageBroker<TKey, TMessage>), options.InstanceLifetime);
+            builder.Services.Add(typeof(IAsyncSubscriber<TKey, TMessage>), typeof(AsyncMessageBroker<TKey, TMessage>), options.InstanceLifetime);
         }
 
-        public static IServiceCollection RegisterUpdInterprocessMessageBroker<TKey, TMessage>(this IServiceCollection services, MessagePipeInterprocessOptions options)
+        public static IMessagePipeBuilder RegisterUpdInterprocessMessageBroker<TKey, TMessage>(this IMessagePipeBuilder builder, MessagePipeInterprocessOptions options)
         {
-            AddAsyncMessageBroker<TKey, TMessage>(services, options);
-            services.Add(typeof(IDistributedPublisher<TKey, TMessage>), typeof(UdpDistributedPublisher<TKey, TMessage>), options.InstanceLifetime);
-            services.Add(typeof(IDistributedSubscriber<TKey, TMessage>), typeof(UdpDistributedSubscriber<TKey, TMessage>), options.InstanceLifetime);
+            AddAsyncMessageBroker<TKey, TMessage>(builder, options);
+            builder.Services.Add(typeof(IDistributedPublisher<TKey, TMessage>), typeof(UdpDistributedPublisher<TKey, TMessage>), options.InstanceLifetime);
+            builder.Services.Add(typeof(IDistributedSubscriber<TKey, TMessage>), typeof(UdpDistributedSubscriber<TKey, TMessage>), options.InstanceLifetime);
 
-            return services;
+            return builder;
         }
 
-        public static IServiceCollection RegisterTcpInterprocessMessageBroker<TKey, TMessage>(this IServiceCollection services, MessagePipeInterprocessOptions options)
+        public static IMessagePipeBuilder RegisterTcpInterprocessMessageBroker<TKey, TMessage>(this IMessagePipeBuilder builder, MessagePipeInterprocessOptions options)
         {
-            AddAsyncMessageBroker<TKey, TMessage>(services, options);
-            services.Add(typeof(IDistributedPublisher<TKey, TMessage>), typeof(TcpDistributedPublisher<TKey, TMessage>), options.InstanceLifetime);
-            services.Add(typeof(IDistributedSubscriber<TKey, TMessage>), typeof(TcpDistributedSubscriber<TKey, TMessage>), options.InstanceLifetime);
+            AddAsyncMessageBroker<TKey, TMessage>(builder, options);
+            builder.Services.Add(typeof(IDistributedPublisher<TKey, TMessage>), typeof(TcpDistributedPublisher<TKey, TMessage>), options.InstanceLifetime);
+            builder.Services.Add(typeof(IDistributedSubscriber<TKey, TMessage>), typeof(TcpDistributedSubscriber<TKey, TMessage>), options.InstanceLifetime);
 
-            return services;
+            return builder;
         }
 
-        //public static IServiceCollection RegisterNamedPipeInterprocessMessageBroker<TKey, TMessage>(this IServiceCollection services, MessagePipeInterprocessOptions options)
+        //public static IMessagePipeBuilder RegisterNamedPipeInterprocessMessageBroker<TKey, TMessage>(this IMessagePipeBuilder builder, MessagePipeInterprocessOptions options)
         //{
-        //    AddAsyncMessageBroker<TKey, TMessage>(services, options);
-        //    services.Add(typeof(IDistributedPublisher<TKey, TMessage>), typeof(NamedPipeDistributedPublisher<TKey, TMessage>), options.InstanceLifetime);
-        //    services.Add(typeof(IDistributedSubscriber<TKey, TMessage>), typeof(NamedPipeDistributedSubscriber<TKey, TMessage>), options.InstanceLifetime);
+        //    AddAsyncMessageBroker<TKey, TMessage>(builder, options);
+        //    builder.Services.Add(typeof(IDistributedPublisher<TKey, TMessage>), typeof(NamedPipeDistributedPublisher<TKey, TMessage>), options.InstanceLifetime);
+        //    builder.Services.Add(typeof(IDistributedSubscriber<TKey, TMessage>), typeof(NamedPipeDistributedSubscriber<TKey, TMessage>), options.InstanceLifetime);
 
-        //    return services;
+        //    return builder;
         //}
 
-        public static IServiceCollection RegisterTcpRemoteRequestHandler<TRequest, TResponse>(this IServiceCollection services, MessagePipeInterprocessOptions options)
+        public static IMessagePipeBuilder RegisterTcpRemoteRequestHandler<TRequest, TResponse>(this IMessagePipeBuilder builder, MessagePipeInterprocessOptions options)
         {
-            services.Add(typeof(IRemoteRequestHandler<TRequest, TResponse>), typeof(TcpRemoteRequestHandler<TRequest, TResponse>), options.InstanceLifetime);
+            builder.Services.Add(typeof(IRemoteRequestHandler<TRequest, TResponse>), typeof(TcpRemoteRequestHandler<TRequest, TResponse>), options.InstanceLifetime);
 
-            return services;
+            return builder;
         }
 
-        //public static IServiceCollection RegisterNamedPipeRemoteRequestHandler<TRequest, TResponse>(this IServiceCollection services, MessagePipeInterprocessOptions options)
+        //public static IMessagePipeBuilder RegisterNamedPipeRemoteRequestHandler<TRequest, TResponse>(this IMessagePipeBuilder builder, MessagePipeInterprocessOptions options)
         //{
-        //    services.Add(typeof(IRemoteRequestHandler<TRequest, TResponse>), typeof(NamedPipeRemoteRequestHandler<TRequest, TResponse>), options.InstanceLifetime);
+        //    builder.Services.Add(typeof(IRemoteRequestHandler<TRequest, TResponse>), typeof(NamedPipeRemoteRequestHandler<TRequest, TResponse>), options.InstanceLifetime);
 
-        //    return services;
+        //    return builder;
         //}
 
 #endif
 #if NET5_0_OR_GREATER
-        public static ReturnType AddMessagePipeUdpInterprocessUds(this IServiceCollection services, string domainSocketPath)
+        public static ReturnType AddMessagePipeUdpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath)
         {
-            return AddMessagePipeUdpInterprocessUds(services, domainSocketPath, _ => { });
+            return AddMessagePipeUdpInterprocessUds(builder, domainSocketPath, _ => { });
         }
-        public static ReturnType AddMessagePipeUdpInterprocessUds(this IServiceCollection services, string domainSocketPath, Action<MessagePipeInterprocessUdpUdsOptions> configure)
+        public static ReturnType AddMessagePipeUdpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath, Action<MessagePipeInterprocessUdpUdsOptions> configure)
         {
             var options = new MessagePipeInterprocessUdpUdsOptions(domainSocketPath);
             configure(options);
 
-            services.AddSingleton(options);
-            services.Add(typeof(UdpWorker), options.InstanceLifetime);
+            builder.Services.AddSingleton(options);
+            builder.Services.Add(typeof(UdpWorker), options.InstanceLifetime);
 
 #if !UNITY_2018_3_OR_NEWER
-            services.Add(typeof(IDistributedPublisher<,>), typeof(UdpDistributedPublisher<,>), options.InstanceLifetime);
-            services.Add(typeof(IDistributedSubscriber<,>), typeof(UdpDistributedSubscriber<,>), options.InstanceLifetime);
-            return services;
+            builder.Services.Add(typeof(IDistributedPublisher<,>), typeof(UdpDistributedPublisher<,>), options.InstanceLifetime);
+            builder.Services.Add(typeof(IDistributedSubscriber<,>), typeof(UdpDistributedSubscriber<,>), options.InstanceLifetime);
+            return builder;
 #else
-            AddAsyncMessageBroker<IInterprocessKey, IInterprocessValue>(services, options);
+            AddAsyncMessageBroker<IInterprocessKey, IInterprocessValue>(builder, options);
             return options;
 #endif
         }
-        public static ReturnType AddMessagePipeTcpInterprocessUds(this IServiceCollection services, string domainSocketPath)
+        public static ReturnType AddMessagePipeTcpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath)
         {
-            return AddMessagePipeTcpInterprocessUds(services, domainSocketPath, _ => { });
+            return AddMessagePipeTcpInterprocessUds(builder, domainSocketPath, _ => { });
         }
 
-        public static ReturnType AddMessagePipeTcpInterprocessUds(this IServiceCollection services, string domainSocketPath, Action<MessagePipeInterprocessTcpUdsOptions> configure)
+        public static ReturnType AddMessagePipeTcpInterprocessUds(this IMessagePipeBuilder builder, string domainSocketPath, Action<MessagePipeInterprocessTcpUdsOptions> configure)
         {
             var options = new MessagePipeInterprocessTcpUdsOptions(domainSocketPath);
             configure(options);
 
-            services.AddSingleton(options);
-            services.Add(typeof(TcpWorker), options.InstanceLifetime);
+            builder.Services.AddSingleton(options);
+            builder.Services.Add(typeof(TcpWorker), options.InstanceLifetime);
 
 #if !UNITY_2018_3_OR_NEWER
-            services.Add(typeof(IDistributedPublisher<,>), typeof(TcpDistributedPublisher<,>), options.InstanceLifetime);
-            services.Add(typeof(IDistributedSubscriber<,>), typeof(TcpDistributedSubscriber<,>), options.InstanceLifetime);
-            services.Add(typeof(IRemoteRequestHandler<,>), typeof(TcpRemoteRequestHandler<,>), options.InstanceLifetime);
-            return services;
+            builder.Services.Add(typeof(IDistributedPublisher<,>), typeof(TcpDistributedPublisher<,>), options.InstanceLifetime);
+            builder.Services.Add(typeof(IDistributedSubscriber<,>), typeof(TcpDistributedSubscriber<,>), options.InstanceLifetime);
+            builder.Services.Add(typeof(IRemoteRequestHandler<,>), typeof(TcpRemoteRequestHandler<,>), options.InstanceLifetime);
+            return builder;
 #else
-            AddAsyncMessageBroker<IInterprocessKey, IInterprocessValue>(services, options);
+            AddAsyncMessageBroker<IInterprocessKey, IInterprocessValue>(builder, options);
             return options;
 #endif
 

--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.VContainer/Runtime/ContainerBuilderExtensions.cs
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.VContainer/Runtime/ContainerBuilderExtensions.cs
@@ -18,10 +18,10 @@ namespace MessagePipe
             MessagePipeOptions options = null;
             var proxy = new ContainerBuilderProxy(builder);
             proxy.AddMessagePipe(x =>
-             {
-                 configure(x);
-                 options = x;
-             });
+            {
+                configure(x);
+                options = x;
+            });
 
             builder.Register<IServiceProvider, ObjectResolverProxy>(Lifetime.Scoped);
 
@@ -155,6 +155,11 @@ namespace MessagePipe
         public static IServiceCollection AsServiceCollection(this IContainerBuilder builder)
         {
             return new ContainerBuilderProxy(builder);
+        }
+
+        public static IMessagePipeBuilder ToMessagePipeBuilder(this IContainerBuilder builder)
+        {
+            return new MessagePipeBuilder(builder.AsServiceCollection());
         }
 
         static Lifetime GetLifetime(InstanceLifetime lifetime)

--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe/Runtime/ServiceCollectionExtensions.cs
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe/Runtime/ServiceCollectionExtensions.cs
@@ -15,12 +15,15 @@ namespace Microsoft.Extensions.DependencyInjection
 namespace MessagePipe
 #endif
 {
+    /// <summary>
+    /// An interface for configuring MessagePipe services.
+    /// </summary>
     public interface IMessagePipeBuilder
     {
         IServiceCollection Services { get; }
     }
 
-    internal class MessagePipeBuilder : IMessagePipeBuilder
+    public class MessagePipeBuilder : IMessagePipeBuilder
     {
         public IServiceCollection Services { get; }
 

--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe/Runtime/ServiceCollectionExtensions.cs
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe/Runtime/ServiceCollectionExtensions.cs
@@ -7,17 +7,37 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
+#if !UNITY_2018_3_OR_NEWER
+namespace Microsoft.Extensions.DependencyInjection
+#else
 namespace MessagePipe
+#endif
 {
+    public interface IMessagePipeBuilder
+    {
+        IServiceCollection Services { get; }
+    }
+
+    internal class MessagePipeBuilder : IMessagePipeBuilder
+    {
+        public IServiceCollection Services { get; }
+
+        public MessagePipeBuilder(IServiceCollection services)
+        {
+            Services = services;
+        }
+    }
+
     public static class ServiceCollectionExtensions
     {
-        public static IServiceCollection AddMessagePipe(this IServiceCollection services)
+        public static IMessagePipeBuilder AddMessagePipe(this IServiceCollection services)
         {
             return AddMessagePipe(services, _ => { });
         }
 
-        public static IServiceCollection AddMessagePipe(this IServiceCollection services, Action<MessagePipeOptions> configure)
+        public static IMessagePipeBuilder AddMessagePipe(this IServiceCollection services, Action<MessagePipeOptions> configure)
         {
             var options = new MessagePipeOptions();
             configure(options);
@@ -137,67 +157,67 @@ namespace MessagePipe
 
 #endif
 
-            return services;
+            return new MessagePipeBuilder(services);
         }
 
 #if !UNITY_2018_3_OR_NEWER
 
-        public static IServiceCollection AddMessageHandlerFilter<T>(this IServiceCollection services)
+        public static IMessagePipeBuilder AddMessageHandlerFilter<T>(this IMessagePipeBuilder builder)
             where T : class, IMessageHandlerFilter
         {
-            services.TryAddTransient<T>();
-            return services;
+            builder.Services.TryAddTransient<T>();
+            return builder;
         }
 
-        public static IServiceCollection AddAsyncMessageHandlerFilter<T>(this IServiceCollection services)
+        public static IMessagePipeBuilder AddAsyncMessageHandlerFilter<T>(this IMessagePipeBuilder builder)
             where T : class, IAsyncMessageHandlerFilter
         {
-            services.TryAddTransient<T>();
-            return services;
+            builder.Services.TryAddTransient<T>();
+            return builder;
         }
 
-        public static IServiceCollection AddRequestHandlerFilter<T>(this IServiceCollection services)
+        public static IMessagePipeBuilder AddRequestHandlerFilter<T>(this IMessagePipeBuilder builder)
             where T : class, IRequestHandlerFilter
         {
-            services.TryAddTransient<T>();
-            return services;
+            builder.Services.TryAddTransient<T>();
+            return builder;
         }
 
-        public static IServiceCollection AddAsyncRequestHandlerFilter<T>(this IServiceCollection services)
+        public static IMessagePipeBuilder AddAsyncRequestHandlerFilter<T>(this IMessagePipeBuilder builder)
             where T : class, IAsyncRequestHandlerFilter
         {
-            services.TryAddTransient<T>();
-            return services;
+            builder.Services.TryAddTransient<T>();
+            return builder;
         }
 
-        public static IServiceCollection AddRequestHandler(this IServiceCollection services, Type type)
+        public static IMessagePipeBuilder AddRequestHandler(this IMessagePipeBuilder builder, Type type)
         {
-            return AddRequestHandlerCore(services, type, typeof(IRequestHandlerCore<,>));
+            return AddRequestHandlerCore(builder, type, typeof(IRequestHandlerCore<,>));
         }
 
-        public static IServiceCollection AddRequestHandler<T>(this IServiceCollection services)
+        public static IMessagePipeBuilder AddRequestHandler<T>(this IMessagePipeBuilder builder)
             where T : IRequestHandler
         {
-            return AddRequestHandler(services, typeof(T));
+            return AddRequestHandler(builder, typeof(T));
         }
 
-        public static IServiceCollection AddAsyncRequestHandler(this IServiceCollection services, Type type)
+        public static IMessagePipeBuilder AddAsyncRequestHandler(this IMessagePipeBuilder builder, Type type)
         {
-            return AddRequestHandlerCore(services, type, typeof(IAsyncRequestHandlerCore<,>));
+            return AddRequestHandlerCore(builder, type, typeof(IAsyncRequestHandlerCore<,>));
         }
 
-        public static IServiceCollection AddAsyncRequestHandler<T>(this IServiceCollection services)
+        public static IMessagePipeBuilder AddAsyncRequestHandler<T>(this IMessagePipeBuilder builder)
             where T : IAsyncRequestHandler
         {
-            return AddAsyncRequestHandler(services, typeof(T));
+            return AddAsyncRequestHandler(builder, typeof(T));
         }
 
-        static IServiceCollection AddRequestHandlerCore(IServiceCollection services, Type type, Type coreType)
+        static IMessagePipeBuilder AddRequestHandlerCore(IMessagePipeBuilder builder, Type type, Type coreType)
         {
-            var options = services.FirstOrDefault(x => x.ServiceType == typeof(MessagePipeOptions));
+            var options = builder.Services.FirstOrDefault(x => x.ServiceType == typeof(MessagePipeOptions));
             if (options == null)
             {
-                throw new ArgumentException($"Not yet added MessagePipeOptions, please call servcies.AddMessagePipe() before.");
+                throw new ArgumentException($"Not yet added MessagePipeOptions, please call services.AddMessagePipe() before.");
             }
             var isAsync = (coreType == typeof(IAsyncRequestHandlerCore<,>));
 
@@ -218,7 +238,7 @@ namespace MessagePipe
                     }
 
                     registered = true;
-                    services.Add(iType, type, ((MessagePipeOptions)options.ImplementationInstance!).RequestHandlerLifetime);
+                    builder.Services.Add(iType, type, ((MessagePipeOptions)options.ImplementationInstance!).RequestHandlerLifetime);
                 }
             }
 
@@ -231,22 +251,22 @@ namespace MessagePipe
                 AsyncRequestHandlerRegistory.Add(coreType);
             }
 
-            return services;
+            return builder;
         }
 
-        public static IServiceCollection AddInMemoryDistributedMessageBroker(this IServiceCollection services)
+        public static IMessagePipeBuilder AddInMemoryDistributedMessageBroker(this IMessagePipeBuilder builder)
         {
-            var options = services.FirstOrDefault(x => x.ServiceType == typeof(MessagePipeOptions));
+            var options = builder.Services.FirstOrDefault(x => x.ServiceType == typeof(MessagePipeOptions));
             if (options == null)
             {
-                throw new ArgumentException($"Not yet added MessagePipeOptions, please call servcies.AddMessagePipe() before.");
+                throw new ArgumentException($"Not yet added MessagePipeOptions, please call services.AddMessagePipe() before.");
             }
 
             var lifetime = ((MessagePipeOptions)options.ImplementationInstance!).InstanceLifetime;
-            services.Add(typeof(IDistributedPublisher<,>), typeof(InMemoryDistributedPublisher<,>), lifetime);
-            services.Add(typeof(IDistributedSubscriber<,>), typeof(InMemoryDistributedSubscriber<,>), lifetime);
+            builder.Services.Add(typeof(IDistributedPublisher<,>), typeof(InMemoryDistributedPublisher<,>), lifetime);
+            builder.Services.Add(typeof(IDistributedSubscriber<,>), typeof(InMemoryDistributedSubscriber<,>), lifetime);
 
-            return services;
+            return builder;
         }
 
         internal static void Add(this IServiceCollection services, Type serviceType, InstanceLifetime lifetime)

--- a/src/MessagePipe.Unity/Assets/Tests/InterprocessTest.cs
+++ b/src/MessagePipe.Unity/Assets/Tests/InterprocessTest.cs
@@ -19,12 +19,12 @@ public class InterprocessTest
         {
         }, (options, builder) =>
         {
-            var sc = builder.AsServiceCollection();
-            var newOptions = sc.AddMessagePipeUdpInterprocess("127.0.0.1", 1192, x =>
+            var messagePipeBuilder = builder.ToMessagePipeBuilder();
+            var newOptions = messagePipeBuilder.AddUdpInterprocess("127.0.0.1", 1192, x =>
             {
                 x.InstanceLifetime = InstanceLifetime.Scoped;
             });
-            sc.RegisterUpdInterprocessMessageBroker<int, int>(newOptions);
+            messagePipeBuilder.RegisterUpdInterprocessMessageBroker<int, int>(newOptions);
         });
 
         using (var provider = rootProvider)
@@ -62,13 +62,13 @@ public class InterprocessTest
         {
         }, (options, builder) =>
         {
-            var sc = builder.AsServiceCollection();
-            var newOptions = sc.AddMessagePipeTcpInterprocess("127.0.0.1", 1211, x =>
+            var messagePipeBuilder = builder.ToMessagePipeBuilder();
+            var newOptions = messagePipeBuilder.AddTcpInterprocess("127.0.0.1", 1211, x =>
              {
                  x.InstanceLifetime = InstanceLifetime.Scoped;
                  x.HostAsServer = true;
              });
-            sc.RegisterTcpInterprocessMessageBroker<int, int>(newOptions);
+            messagePipeBuilder.RegisterTcpInterprocessMessageBroker<int, int>(newOptions);
         });
 
         using (var provider = rootProvider)

--- a/src/MessagePipe/ServiceCollectionExtensions.cs
+++ b/src/MessagePipe/ServiceCollectionExtensions.cs
@@ -15,12 +15,15 @@ namespace Microsoft.Extensions.DependencyInjection
 namespace MessagePipe
 #endif
 {
+    /// <summary>
+    /// An interface for configuring MessagePipe services.
+    /// </summary>
     public interface IMessagePipeBuilder
     {
         IServiceCollection Services { get; }
     }
 
-    internal class MessagePipeBuilder : IMessagePipeBuilder
+    public class MessagePipeBuilder : IMessagePipeBuilder
     {
         public IServiceCollection Services { get; }
 

--- a/src/MessagePipe/ServiceCollectionExtensions.cs
+++ b/src/MessagePipe/ServiceCollectionExtensions.cs
@@ -7,17 +7,37 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
+#if !UNITY_2018_3_OR_NEWER
+namespace Microsoft.Extensions.DependencyInjection
+#else
 namespace MessagePipe
+#endif
 {
+    public interface IMessagePipeBuilder
+    {
+        IServiceCollection Services { get; }
+    }
+
+    internal class MessagePipeBuilder : IMessagePipeBuilder
+    {
+        public IServiceCollection Services { get; }
+
+        public MessagePipeBuilder(IServiceCollection services)
+        {
+            Services = services;
+        }
+    }
+
     public static class ServiceCollectionExtensions
     {
-        public static IServiceCollection AddMessagePipe(this IServiceCollection services)
+        public static IMessagePipeBuilder AddMessagePipe(this IServiceCollection services)
         {
             return AddMessagePipe(services, _ => { });
         }
 
-        public static IServiceCollection AddMessagePipe(this IServiceCollection services, Action<MessagePipeOptions> configure)
+        public static IMessagePipeBuilder AddMessagePipe(this IServiceCollection services, Action<MessagePipeOptions> configure)
         {
             var options = new MessagePipeOptions();
             configure(options);
@@ -137,67 +157,67 @@ namespace MessagePipe
 
 #endif
 
-            return services;
+            return new MessagePipeBuilder(services);
         }
 
 #if !UNITY_2018_3_OR_NEWER
 
-        public static IServiceCollection AddMessageHandlerFilter<T>(this IServiceCollection services)
+        public static IMessagePipeBuilder AddMessageHandlerFilter<T>(this IMessagePipeBuilder builder)
             where T : class, IMessageHandlerFilter
         {
-            services.TryAddTransient<T>();
-            return services;
+            builder.Services.TryAddTransient<T>();
+            return builder;
         }
 
-        public static IServiceCollection AddAsyncMessageHandlerFilter<T>(this IServiceCollection services)
+        public static IMessagePipeBuilder AddAsyncMessageHandlerFilter<T>(this IMessagePipeBuilder builder)
             where T : class, IAsyncMessageHandlerFilter
         {
-            services.TryAddTransient<T>();
-            return services;
+            builder.Services.TryAddTransient<T>();
+            return builder;
         }
 
-        public static IServiceCollection AddRequestHandlerFilter<T>(this IServiceCollection services)
+        public static IMessagePipeBuilder AddRequestHandlerFilter<T>(this IMessagePipeBuilder builder)
             where T : class, IRequestHandlerFilter
         {
-            services.TryAddTransient<T>();
-            return services;
+            builder.Services.TryAddTransient<T>();
+            return builder;
         }
 
-        public static IServiceCollection AddAsyncRequestHandlerFilter<T>(this IServiceCollection services)
+        public static IMessagePipeBuilder AddAsyncRequestHandlerFilter<T>(this IMessagePipeBuilder builder)
             where T : class, IAsyncRequestHandlerFilter
         {
-            services.TryAddTransient<T>();
-            return services;
+            builder.Services.TryAddTransient<T>();
+            return builder;
         }
 
-        public static IServiceCollection AddRequestHandler(this IServiceCollection services, Type type)
+        public static IMessagePipeBuilder AddRequestHandler(this IMessagePipeBuilder builder, Type type)
         {
-            return AddRequestHandlerCore(services, type, typeof(IRequestHandlerCore<,>));
+            return AddRequestHandlerCore(builder, type, typeof(IRequestHandlerCore<,>));
         }
 
-        public static IServiceCollection AddRequestHandler<T>(this IServiceCollection services)
+        public static IMessagePipeBuilder AddRequestHandler<T>(this IMessagePipeBuilder builder)
             where T : IRequestHandler
         {
-            return AddRequestHandler(services, typeof(T));
+            return AddRequestHandler(builder, typeof(T));
         }
 
-        public static IServiceCollection AddAsyncRequestHandler(this IServiceCollection services, Type type)
+        public static IMessagePipeBuilder AddAsyncRequestHandler(this IMessagePipeBuilder builder, Type type)
         {
-            return AddRequestHandlerCore(services, type, typeof(IAsyncRequestHandlerCore<,>));
+            return AddRequestHandlerCore(builder, type, typeof(IAsyncRequestHandlerCore<,>));
         }
 
-        public static IServiceCollection AddAsyncRequestHandler<T>(this IServiceCollection services)
+        public static IMessagePipeBuilder AddAsyncRequestHandler<T>(this IMessagePipeBuilder builder)
             where T : IAsyncRequestHandler
         {
-            return AddAsyncRequestHandler(services, typeof(T));
+            return AddAsyncRequestHandler(builder, typeof(T));
         }
 
-        static IServiceCollection AddRequestHandlerCore(IServiceCollection services, Type type, Type coreType)
+        static IMessagePipeBuilder AddRequestHandlerCore(IMessagePipeBuilder builder, Type type, Type coreType)
         {
-            var options = services.FirstOrDefault(x => x.ServiceType == typeof(MessagePipeOptions));
+            var options = builder.Services.FirstOrDefault(x => x.ServiceType == typeof(MessagePipeOptions));
             if (options == null)
             {
-                throw new ArgumentException($"Not yet added MessagePipeOptions, please call servcies.AddMessagePipe() before.");
+                throw new ArgumentException($"Not yet added MessagePipeOptions, please call services.AddMessagePipe() before.");
             }
             var isAsync = (coreType == typeof(IAsyncRequestHandlerCore<,>));
 
@@ -218,7 +238,7 @@ namespace MessagePipe
                     }
 
                     registered = true;
-                    services.Add(iType, type, ((MessagePipeOptions)options.ImplementationInstance!).RequestHandlerLifetime);
+                    builder.Services.Add(iType, type, ((MessagePipeOptions)options.ImplementationInstance!).RequestHandlerLifetime);
                 }
             }
 
@@ -231,22 +251,22 @@ namespace MessagePipe
                 AsyncRequestHandlerRegistory.Add(coreType);
             }
 
-            return services;
+            return builder;
         }
 
-        public static IServiceCollection AddInMemoryDistributedMessageBroker(this IServiceCollection services)
+        public static IMessagePipeBuilder AddInMemoryDistributedMessageBroker(this IMessagePipeBuilder builder)
         {
-            var options = services.FirstOrDefault(x => x.ServiceType == typeof(MessagePipeOptions));
+            var options = builder.Services.FirstOrDefault(x => x.ServiceType == typeof(MessagePipeOptions));
             if (options == null)
             {
-                throw new ArgumentException($"Not yet added MessagePipeOptions, please call servcies.AddMessagePipe() before.");
+                throw new ArgumentException($"Not yet added MessagePipeOptions, please call services.AddMessagePipe() before.");
             }
 
             var lifetime = ((MessagePipeOptions)options.ImplementationInstance!).InstanceLifetime;
-            services.Add(typeof(IDistributedPublisher<,>), typeof(InMemoryDistributedPublisher<,>), lifetime);
-            services.Add(typeof(IDistributedSubscriber<,>), typeof(InMemoryDistributedSubscriber<,>), lifetime);
+            builder.Services.Add(typeof(IDistributedPublisher<,>), typeof(InMemoryDistributedPublisher<,>), lifetime);
+            builder.Services.Add(typeof(IDistributedSubscriber<,>), typeof(InMemoryDistributedSubscriber<,>), lifetime);
 
-            return services;
+            return builder;
         }
 
         internal static void Add(this IServiceCollection services, Type serviceType, InstanceLifetime lifetime)

--- a/tests/MessagePipe.Benchmark/BenchmarkDotNetRun.cs
+++ b/tests/MessagePipe.Benchmark/BenchmarkDotNetRun.cs
@@ -36,7 +36,7 @@ namespace MessagePipe.Benchmark
 
         public BenchmarkDotNetRun()
         {
-            var provider = new ServiceCollection().AddMessagePipe().BuildServiceProvider();
+            var provider = new ServiceCollection().AddMessagePipe().Services.BuildServiceProvider();
 
             prism = new Prism.Events.EventAggregator().GetEvent<Message>();
             prismStrong = new Prism.Events.EventAggregator().GetEvent<Message>();

--- a/tests/MessagePipe.Benchmark/PublishOps.cs
+++ b/tests/MessagePipe.Benchmark/PublishOps.cs
@@ -91,7 +91,7 @@ namespace MessagePipe.Benchmark
 
         public unsafe PublishOps()
         {
-            var provider = new ServiceCollection().AddMessagePipe().BuildServiceProvider();
+            var provider = new ServiceCollection().AddMessagePipe().Services.BuildServiceProvider();
 
             prism = new Prism.Events.EventAggregator().GetEvent<Message>();
             prismStrong = new Prism.Events.EventAggregator().GetEvent<Message>();
@@ -110,11 +110,11 @@ namespace MessagePipe.Benchmark
 
 
 
-            var px = new ServiceCollection().AddMessagePipe().BuildServiceProvider();
+            var px = new ServiceCollection().AddMessagePipe().Services.BuildServiceProvider();
             filter1 = px.GetRequiredService<IPublisher<Message>>();
             var filter1Sub = px.GetRequiredService<ISubscriber<Message>>();
 
-            var px2 = new ServiceCollection().AddMessagePipe().BuildServiceProvider();
+            var px2 = new ServiceCollection().AddMessagePipe().Services.BuildServiceProvider();
             filter2 = px2.GetRequiredService<IPublisher<Message>>();
             var filter2Sub = px2.GetRequiredService<ISubscriber<Message>>();
 

--- a/tests/MessagePipe.Interprocess.Benchmark/TcpBenchmark.cs
+++ b/tests/MessagePipe.Interprocess.Benchmark/TcpBenchmark.cs
@@ -22,7 +22,7 @@ namespace MessagePipe.Interprocess.Benchmark
         {
             var services = new ServiceCollection();
             services.AddMessagePipe()
-                .AddMessagePipeTcpInterprocess("127.0.0.1", 10000, opts =>
+                .AddTcpInterprocess("127.0.0.1", 10000, opts =>
                 {
                     opts.HostAsServer = true;
                 });
@@ -37,7 +37,7 @@ namespace MessagePipe.Interprocess.Benchmark
             }
             var services = new ServiceCollection();
             services.AddMessagePipe()
-                .AddMessagePipeTcpInterprocessUds(_TcpUdsSocketPath, opt =>
+                .AddTcpInterprocessUds(_TcpUdsSocketPath, opt =>
                 {
                     opt.HostAsServer = true;
                     opt.SendBufferSize = Math.Min(DataSize, 0x1000);

--- a/tests/MessagePipe.Interprocess.Benchmark/TcpBenchmark.cs
+++ b/tests/MessagePipe.Interprocess.Benchmark/TcpBenchmark.cs
@@ -21,11 +21,11 @@ namespace MessagePipe.Interprocess.Benchmark
         IServiceProvider CreateTcpIpServiceProvider()
         {
             var services = new ServiceCollection();
-            services.AddMessagePipe();
-            services.AddMessagePipeTcpInterprocess("127.0.0.1", 10000, opts =>
-            {
-                opts.HostAsServer = true;
-            });
+            services.AddMessagePipe()
+                .AddMessagePipeTcpInterprocess("127.0.0.1", 10000, opts =>
+                {
+                    opts.HostAsServer = true;
+                });
             return services.BuildServiceProvider();
         }
         IServiceProvider CreateTcpUdsServiceProvider()
@@ -36,13 +36,13 @@ namespace MessagePipe.Interprocess.Benchmark
                 System.IO.File.Delete(_TcpUdsSocketPath);
             }
             var services = new ServiceCollection();
-            services.AddMessagePipe();
-            services.AddMessagePipeTcpInterprocessUds(_TcpUdsSocketPath, opt =>
-            {
-                opt.HostAsServer = true;
-                opt.SendBufferSize = Math.Min(DataSize, 0x1000);
-                opt.ReceiveBufferSize = Math.Min(DataSize, 0x1000);
-            });
+            services.AddMessagePipe()
+                .AddMessagePipeTcpInterprocessUds(_TcpUdsSocketPath, opt =>
+                {
+                    opt.HostAsServer = true;
+                    opt.SendBufferSize = Math.Min(DataSize, 0x1000);
+                    opt.ReceiveBufferSize = Math.Min(DataSize, 0x1000);
+                });
             return services.BuildServiceProvider();
         }
         [GlobalSetup]

--- a/tests/MessagePipe.Interprocess.Benchmark/TcpParallelBenchmark.cs
+++ b/tests/MessagePipe.Interprocess.Benchmark/TcpParallelBenchmark.cs
@@ -22,7 +22,7 @@ namespace MessagePipe.Interprocess.Benchmark
         {
             var services = new ServiceCollection();
             services.AddMessagePipe()
-                .AddMessagePipeTcpInterprocess(ip, port, opts =>
+                .AddTcpInterprocess(ip, port, opts =>
                 {
                     opts.HostAsServer = true;
                 });
@@ -36,7 +36,7 @@ namespace MessagePipe.Interprocess.Benchmark
             }
             var services = new ServiceCollection();
             services.AddMessagePipe()
-                .AddMessagePipeTcpInterprocessUds(socketPath, opt =>
+                .AddTcpInterprocessUds(socketPath, opt =>
                 {
                     opt.HostAsServer = true;
                     opt.SendBufferSize = Math.Min(DataSize, 0x1000);

--- a/tests/MessagePipe.Interprocess.Benchmark/TcpParallelBenchmark.cs
+++ b/tests/MessagePipe.Interprocess.Benchmark/TcpParallelBenchmark.cs
@@ -21,11 +21,11 @@ namespace MessagePipe.Interprocess.Benchmark
         IServiceProvider CreateTcpIpServiceProvider(string ip, int port)
         {
             var services = new ServiceCollection();
-            services.AddMessagePipe();
-            services.AddMessagePipeTcpInterprocess(ip, port, opts =>
-            {
-                opts.HostAsServer = true;
-            });
+            services.AddMessagePipe()
+                .AddMessagePipeTcpInterprocess(ip, port, opts =>
+                {
+                    opts.HostAsServer = true;
+                });
             return services.BuildServiceProvider();
         }
         IServiceProvider CreateTcpUdsServiceProvider(string socketPath)
@@ -35,13 +35,13 @@ namespace MessagePipe.Interprocess.Benchmark
                 System.IO.File.Delete(socketPath);
             }
             var services = new ServiceCollection();
-            services.AddMessagePipe();
-            services.AddMessagePipeTcpInterprocessUds(socketPath, opt =>
-            {
-                opt.HostAsServer = true;
-                opt.SendBufferSize = Math.Min(DataSize, 0x1000);
-                opt.ReceiveBufferSize = Math.Min(DataSize, 0x1000);
-            });
+            services.AddMessagePipe()
+                .AddMessagePipeTcpInterprocessUds(socketPath, opt =>
+                {
+                    opt.HostAsServer = true;
+                    opt.SendBufferSize = Math.Min(DataSize, 0x1000);
+                    opt.ReceiveBufferSize = Math.Min(DataSize, 0x1000);
+                });
             return services.BuildServiceProvider();
         }
         IServiceProvider? _TcpIpProvider = null;

--- a/tests/MessagePipe.Interprocess.Tests/_TestHelper.cs
+++ b/tests/MessagePipe.Interprocess.Tests/_TestHelper.cs
@@ -9,55 +9,55 @@ namespace MessagePipe.Interprocess.Tests
         public static IServiceProvider BuildServiceProviderUdp(string host, int port, ITestOutputHelper helper)
         {
             var sc = new ServiceCollection();
-            sc.AddMessagePipe();
-            sc.AddMessagePipeUdpInterprocess(host, port, x =>
-            {
-                x.UnhandledErrorHandler = (msg, e) => helper.WriteLine(msg + e);
-            });
+            sc.AddMessagePipe()
+                .AddMessagePipeUdpInterprocess(host, port, x =>
+                {
+                    x.UnhandledErrorHandler = (msg, e) => helper.WriteLine(msg + e);
+                });
             return sc.BuildServiceProvider();
         }
         public static IServiceProvider BuildServiceProviderUdpWithUds(string domainSocketPath, ITestOutputHelper helper)
         {
             var sc = new ServiceCollection();
-            sc.AddMessagePipe();
-            sc.AddMessagePipeUdpInterprocessUds(domainSocketPath, x =>
-            {
-                x.UnhandledErrorHandler = (msg, e) => helper.WriteLine(msg + e);
-            });
+            sc.AddMessagePipe()
+                .AddMessagePipeUdpInterprocessUds(domainSocketPath, x =>
+                {
+                    x.UnhandledErrorHandler = (msg, e) => helper.WriteLine(msg + e);
+                });
             return sc.BuildServiceProvider();
         }
         public static IServiceProvider BuildServiceProviderTcp(string host, int port, ITestOutputHelper helper, bool asServer = true)
         {
             var sc = new ServiceCollection();
-            sc.AddMessagePipe();
-            sc.AddMessagePipeTcpInterprocess(host, port, x =>
-            {
-                x.HostAsServer = asServer;
-                x.UnhandledErrorHandler = (msg, e) => helper.WriteLine(msg + e);
-            });
+            sc.AddMessagePipe()
+                .AddMessagePipeTcpInterprocess(host, port, x =>
+                {
+                    x.HostAsServer = asServer;
+                    x.UnhandledErrorHandler = (msg, e) => helper.WriteLine(msg + e);
+                });
             return sc.BuildServiceProvider();
         }
         public static IServiceProvider BuildServiceProviderTcpWithUds(string domainSocketPath, ITestOutputHelper helper, bool asServer = true)
         {
             var sc = new ServiceCollection();
-            sc.AddMessagePipe();
-            sc.AddMessagePipeTcpInterprocessUds(domainSocketPath, x =>
-            {
-                x.HostAsServer = asServer;
-                x.UnhandledErrorHandler = (msg, e) => helper.WriteLine(msg + e);
-            });
+            sc.AddMessagePipe()
+                .AddMessagePipeTcpInterprocessUds(domainSocketPath, x =>
+                {
+                    x.HostAsServer = asServer;
+                    x.UnhandledErrorHandler = (msg, e) => helper.WriteLine(msg + e);
+                });
             return sc.BuildServiceProvider();
         }
 
         public static IServiceProvider BuildServiceProviderNamedPipe(string pipeName, ITestOutputHelper helper, bool asServer = true)
         {
             var sc = new ServiceCollection();
-            sc.AddMessagePipe();
-            sc.AddMessagePipeNamedPipeInterprocess(pipeName, x =>
-            {
-                x.HostAsServer = asServer;
-                x.UnhandledErrorHandler = (msg, e) => helper.WriteLine(msg + e);
-            });
+            sc.AddMessagePipe()
+                .AddMessagePipeNamedPipeInterprocess(pipeName, x =>
+                {
+                    x.HostAsServer = asServer;
+                    x.UnhandledErrorHandler = (msg, e) => helper.WriteLine(msg + e);
+                });
             return sc.BuildServiceProvider();
         }
     }

--- a/tests/MessagePipe.Interprocess.Tests/_TestHelper.cs
+++ b/tests/MessagePipe.Interprocess.Tests/_TestHelper.cs
@@ -10,7 +10,7 @@ namespace MessagePipe.Interprocess.Tests
         {
             var sc = new ServiceCollection();
             sc.AddMessagePipe()
-                .AddMessagePipeUdpInterprocess(host, port, x =>
+                .AddUdpInterprocess(host, port, x =>
                 {
                     x.UnhandledErrorHandler = (msg, e) => helper.WriteLine(msg + e);
                 });
@@ -20,7 +20,7 @@ namespace MessagePipe.Interprocess.Tests
         {
             var sc = new ServiceCollection();
             sc.AddMessagePipe()
-                .AddMessagePipeUdpInterprocessUds(domainSocketPath, x =>
+                .AddUdpInterprocessUds(domainSocketPath, x =>
                 {
                     x.UnhandledErrorHandler = (msg, e) => helper.WriteLine(msg + e);
                 });
@@ -30,7 +30,7 @@ namespace MessagePipe.Interprocess.Tests
         {
             var sc = new ServiceCollection();
             sc.AddMessagePipe()
-                .AddMessagePipeTcpInterprocess(host, port, x =>
+                .AddTcpInterprocess(host, port, x =>
                 {
                     x.HostAsServer = asServer;
                     x.UnhandledErrorHandler = (msg, e) => helper.WriteLine(msg + e);
@@ -41,7 +41,7 @@ namespace MessagePipe.Interprocess.Tests
         {
             var sc = new ServiceCollection();
             sc.AddMessagePipe()
-                .AddMessagePipeTcpInterprocessUds(domainSocketPath, x =>
+                .AddTcpInterprocessUds(domainSocketPath, x =>
                 {
                     x.HostAsServer = asServer;
                     x.UnhandledErrorHandler = (msg, e) => helper.WriteLine(msg + e);
@@ -53,7 +53,7 @@ namespace MessagePipe.Interprocess.Tests
         {
             var sc = new ServiceCollection();
             sc.AddMessagePipe()
-                .AddMessagePipeNamedPipeInterprocess(pipeName, x =>
+                .AddNamedPipeInterprocess(pipeName, x =>
                 {
                     x.HostAsServer = asServer;
                     x.UnhandledErrorHandler = (msg, e) => helper.WriteLine(msg + e);

--- a/tests/MessagePipe.Nats.Tests/NatsPubSub.cs
+++ b/tests/MessagePipe.Nats.Tests/NatsPubSub.cs
@@ -123,11 +123,11 @@ public static class TestHelper
 
         if (serializer == default)
         {
-            builder.AddMessagePipeNats(new NatsConnectionFactory());
+            builder.AddNats(new NatsConnectionFactory());
         }
         else
         {
-            builder.AddMessagePipeNats(new NatsConnectionFactory(NatsOptions.Default with
+            builder.AddNats(new NatsConnectionFactory(NatsOptions.Default with
             {
                 Serializer = serializer
             }));

--- a/tests/MessagePipe.Nats.Tests/NatsPubSub.cs
+++ b/tests/MessagePipe.Nats.Tests/NatsPubSub.cs
@@ -119,15 +119,15 @@ public static class TestHelper
     public static IServiceProvider BuildNatsServiceProvider(INatsSerializer? serializer = default)
     {
         var sc = new ServiceCollection();
-        sc.AddMessagePipe();
+        var builder = sc.AddMessagePipe();
 
         if (serializer == default)
         {
-            sc.AddMessagePipeNats(new NatsConnectionFactory());
+            builder.AddMessagePipeNats(new NatsConnectionFactory());
         }
         else
         {
-            sc.AddMessagePipeNats(new NatsConnectionFactory(NatsOptions.Default with
+            builder.AddMessagePipeNats(new NatsConnectionFactory(NatsOptions.Default with
             {
                 Serializer = serializer
             }));

--- a/tests/MessagePipe.Redis.Tests/ConnectionMultiplexerFactoryTest.cs
+++ b/tests/MessagePipe.Redis.Tests/ConnectionMultiplexerFactoryTest.cs
@@ -16,8 +16,8 @@ public class ConnectionMultiplexerFactoryTest
     {
         var connection = TestHelper.GetLocalConnectionMultiplexer();
         var services = new ServiceCollection();
-        services.AddMessagePipe();
-        services.AddMessagePipeRedis(connection);
+        services.AddMessagePipe()
+                .AddRedis(connection);
         var sp = services.BuildServiceProvider();
 
         var publisher = sp.GetRequiredService<IDistributedPublisher<string, string>>();
@@ -37,8 +37,8 @@ public class ConnectionMultiplexerFactoryTest
         var connection = TestHelper.GetLocalConnectionMultiplexer();
         var services = new ServiceCollection();
         services.AddSingleton<IConnectionMultiplexer>(connection);
-        services.AddMessagePipe();
-        services.AddMessagePipeRedis<TestConnectionMultiplexerFactory>();
+        services.AddMessagePipe()
+                .AddRedis<TestConnectionMultiplexerFactory>();
         var sp = services.BuildServiceProvider();
 
         var publisher = sp.GetRequiredService<IDistributedPublisher<string, string>>();

--- a/tests/MessagePipe.Redis.Tests/_TestHelper.cs
+++ b/tests/MessagePipe.Redis.Tests/_TestHelper.cs
@@ -38,24 +38,24 @@ namespace MessagePipe.Tests
         public static IServiceProvider BuildRedisServiceProvider(IConnectionMultiplexer connection)
         {
             var sc = new ServiceCollection();
-            sc.AddMessagePipe();
-            sc.AddMessagePipeRedis(connection);
+            sc.AddMessagePipe()
+              .AddMessagePipeRedis(connection);
             return sc.BuildServiceProvider();
         }
 
         public static IServiceProvider BuildRedisServiceProvider(IConnectionMultiplexer connection, Action<MessagePipeOptions> configure)
         {
             var sc = new ServiceCollection();
-            sc.AddMessagePipe(configure);
-            sc.AddMessagePipeRedis(connection);
+            sc.AddMessagePipe(configure)
+              .AddMessagePipeRedis(connection);
             return sc.BuildServiceProvider();
         }
 
         public static IServiceProvider BuildRedisServiceProvider(IConnectionMultiplexer connection, Action<MessagePipeOptions> configure, Action<MessagePipeRedisOptions> redisConfigure)
         {
             var sc = new ServiceCollection();
-            sc.AddMessagePipe(configure);
-            sc.AddMessagePipeRedis(connection, redisConfigure);
+            sc.AddMessagePipe(configure)
+              .AddMessagePipeRedis(connection, redisConfigure);
             return sc.BuildServiceProvider();
         }
     }

--- a/tests/MessagePipe.Redis.Tests/_TestHelper.cs
+++ b/tests/MessagePipe.Redis.Tests/_TestHelper.cs
@@ -39,7 +39,7 @@ namespace MessagePipe.Tests
         {
             var sc = new ServiceCollection();
             sc.AddMessagePipe()
-              .AddMessagePipeRedis(connection);
+              .AddRedis(connection);
             return sc.BuildServiceProvider();
         }
 
@@ -47,7 +47,7 @@ namespace MessagePipe.Tests
         {
             var sc = new ServiceCollection();
             sc.AddMessagePipe(configure)
-              .AddMessagePipeRedis(connection);
+              .AddRedis(connection);
             return sc.BuildServiceProvider();
         }
 
@@ -55,7 +55,7 @@ namespace MessagePipe.Tests
         {
             var sc = new ServiceCollection();
             sc.AddMessagePipe(configure)
-              .AddMessagePipeRedis(connection, redisConfigure);
+              .AddRedis(connection, redisConfigure);
             return sc.BuildServiceProvider();
         }
     }

--- a/tests/MessagePipe.Tests/GlobalMixFilterTest.cs
+++ b/tests/MessagePipe.Tests/GlobalMixFilterTest.cs
@@ -23,7 +23,7 @@ namespace MessagePipe.Tests
             }, builder =>
             {
                 builder.AddMessageHandlerFilter<MyFilter<int>>();
-                builder.AddSingleton(store);
+                builder.Services.AddSingleton(store);
             });
 
             var pub = provider.GetRequiredService<IPublisher<int>>();
@@ -54,7 +54,7 @@ namespace MessagePipe.Tests
             }, builder =>
             {
                 builder.AddRequestHandler<MyRequestHandler>();
-                builder.AddSingleton(store);
+                builder.Services.AddSingleton(store);
             });
 
             var handler = provider.GetRequiredService<IRequestHandler<int, int>>();
@@ -82,7 +82,7 @@ namespace MessagePipe.Tests
             {
                 builder.AddRequestHandler<MyRequestHandler>();
                 builder.AddRequestHandler<MyRequestHandler2>();
-                builder.AddSingleton(store);
+                builder.Services.AddSingleton(store);
             });
 
             var handler = provider.GetRequiredService<IRequestAllHandler<int, int>>();

--- a/tests/MessagePipe.Tests/_TestHelper.cs
+++ b/tests/MessagePipe.Tests/_TestHelper.cs
@@ -19,19 +19,19 @@ namespace MessagePipe.Tests
             return sc.BuildServiceProvider();
         }
 
-        public static IServiceProvider BuildServiceProvider2(Action<ServiceCollection> configureService)
+        public static IServiceProvider BuildServiceProvider2(Action<IMessagePipeBuilder> configureService)
         {
             var sc = new ServiceCollection();
-            sc.AddMessagePipe();
-            configureService(sc);
+            var builder = sc.AddMessagePipe();
+            configureService(builder);
             return sc.BuildServiceProvider();
         }
 
-        public static IServiceProvider BuildServiceProvider3(Action<MessagePipeOptions> configure, Action<ServiceCollection> configureService)
+        public static IServiceProvider BuildServiceProvider3(Action<MessagePipeOptions> configure, Action<IMessagePipeBuilder> configureService)
         {
             var sc = new ServiceCollection();
-            sc.AddMessagePipe(configure);
-            configureService(sc);
+            var builder = sc.AddMessagePipe(configure);
+            configureService(builder);
             return sc.BuildServiceProvider();
         }
     }


### PR DESCRIPTION
This PR changes to Builder pattern like ASP.NET Core. (`AddControllers`, `AddGrpc` etc..)
This helps to organize the scattered extension methods to `IServiceCollection` in one place.

### Before
![image](https://github.com/Cysharp/MessagePipe/assets/9012/09f45303-159d-4a9a-b575-8cb5d0bfa156)
### After
![image](https://github.com/Cysharp/MessagePipe/assets/9012/035c6d4c-1180-4dba-a64f-6995b45263bd)

