### PR TITLE
Support auto resolving with VContainer for ISubscriber,IPublisher,etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1179,7 +1179,8 @@ You need to install Core library and choose [VContainer](https://github.com/hada
 
 Andalso, requires [UniTask](https://github.com/Cysharp/UniTask) to install, all `ValueTask` declaration in .NET is replaced to `UniTask`.
 
-Unity version does not have open generics support(for IL2CPP) and does not support auto registration. Therefore, all required types need to be manually registered.
+> [!NOTE]
+> Unity version does not have open generics support(for IL2CPP) and does not support auto registration. Therefore, all required types need to be manually registered.
 
 VContainer's installation sample.
 
@@ -1232,6 +1233,15 @@ public class MessagePipeDemo : VContainer.Unity.IStartable
     }
 }
 ```
+
+> [!TIP]
+> If you are using Unity 2022.1 or later and VContainer 1.14.0 or later, you do not need `RegsiterMessageBroker<>`. 
+> A set of types including `ISubscriber<>`, `IPublisher<>` or its asynchronous version will be resolved automatically.
+> Note that `IRequesthandler<>` and `IRequestAllHanlder<>` still require manual registration.
+
+
+Unity version does not have open generics support(for IL2CPP) and does not support auto registration. Therefore, all required types need to be manually registered.
+
 
 Zenject's installation sample.
 

--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.VContainer/Runtime/TypeProxy.cs
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe.VContainer/Runtime/TypeProxy.cs
@@ -46,6 +46,15 @@ namespace MessagePipe.VContainer
             builder.Register(implementationType, lifetime).As(serviceType);
         }
 
+        public void Add(Type serviceType, InstanceLifetime lifetime)
+        {
+            var l = (lifetime == InstanceLifetime.Singleton) ? Lifetime.Singleton
+                : (lifetime == InstanceLifetime.Scoped) ? Lifetime.Scoped
+                : Lifetime.Transient;
+            
+            builder.Register(serviceType, l);
+        }
+
         public void Add(Type serviceType, Type implementationType, InstanceLifetime lifetime)
         {
             var l = (lifetime == InstanceLifetime.Singleton) ? Lifetime.Singleton

--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe/Runtime/MessagePipe.asmdef
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe/Runtime/MessagePipe.asmdef
@@ -1,6 +1,5 @@
 {
     "name": "MessagePipe",
-    "rootNamespace": "MessagePipe",
     "references": [
         "UniTask",
         "UniTask.Linq"
@@ -12,6 +11,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "jp.hadashikick.vcontainer",
+            "expression": "1.14.0",
+            "define": "MESSAGEPIPE_OPENGENERICS_SUPPORT"
+        }
+    ],
     "noEngineReferences": true
 }

--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe/Runtime/ServiceCollectionExtensions.cs
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe/Runtime/ServiceCollectionExtensions.cs
@@ -40,7 +40,7 @@ namespace MessagePipe
                 services.TryAddTransient(item); // filter itself is Transient
             }
 
-#if !UNITY_2018_3_OR_NEWER || MESSAGEPIPE_OPENGENERICS_SUPPORT
+#if !UNITY_2018_3_OR_NEWER || (MESSAGEPIPE_OPENGENERICS_SUPPORT && UNITY_2022_1_OR_NEWER)
             // open generics implemntations(.NET Only)
 
             {

--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe/Runtime/ServiceCollectionExtensions.cs
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe/Runtime/ServiceCollectionExtensions.cs
@@ -40,7 +40,7 @@ namespace MessagePipe
                 services.TryAddTransient(item); // filter itself is Transient
             }
 
-#if !UNITY_2018_3_OR_NEWER
+#if !UNITY_2018_3_OR_NEWER || MESSAGEPIPE_OPENGENERICS_SUPPORT
             // open generics implemntations(.NET Only)
 
             {
@@ -107,6 +107,8 @@ namespace MessagePipe
 
             var lifetime2 = options.RequestHandlerLifetime; // requesthandler lifetime
 
+#endif
+#if !UNITY_2018_3_OR_NEWER
             // RequestHandler
             services.Add(typeof(IRequestHandler<,>), typeof(RequestHandler<,>), lifetime2);
             services.Add(typeof(IAsyncRequestHandler<,>), typeof(AsyncRequestHandler<,>), lifetime2);
@@ -114,7 +116,7 @@ namespace MessagePipe
             // RequestAll
             services.Add(typeof(IRequestAllHandler<,>), typeof(RequestAllHandler<,>), lifetime2);
             services.Add(typeof(IAsyncRequestAllHandler<,>), typeof(AsyncRequestAllHandler<,>), lifetime2);
-
+            
             // auto registration is .NET only.
             if (options.EnableAutoRegistration)
             {

--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe/Runtime/Unity/BuiltinContainerBuilder.cs
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe/Runtime/Unity/BuiltinContainerBuilder.cs
@@ -169,6 +169,10 @@ namespace MessagePipe
         }
 
 
+        public void Add(Type serviceType, InstanceLifetime lifetime)
+        {
+            Add(serviceType, serviceType, lifetime);
+        }
 
         public void Add(Type serviceType, Type implementationType, InstanceLifetime lifetime)
         {

--- a/src/MessagePipe.Unity/Assets/Plugins/MessagePipe/Runtime/Unity/DependencyInjectionShims.cs
+++ b/src/MessagePipe.Unity/Assets/Plugins/MessagePipe/Runtime/Unity/DependencyInjectionShims.cs
@@ -27,6 +27,7 @@ namespace MessagePipe
 
     public interface IServiceCollection
     {
+        void Add(Type serviceType, InstanceLifetime lifetime);
         void Add(Type serviceType, Type implementationType, InstanceLifetime lifetime);
         void AddSingleton<T>(T instance);
         void AddSingleton(Type type);

--- a/src/MessagePipe.Unity/Assets/Tests/TestHelper.cs
+++ b/src/MessagePipe.Unity/Assets/Tests/TestHelper.cs
@@ -5,6 +5,13 @@ using Zenject;
 
 public static class TestHelper
 {
+    public static IObjectResolver BuildVContainer()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterMessagePipe();
+        return builder.Build();
+    }
+    
     public static IObjectResolver BuildVContainer(Action<MessagePipeOptions> configure, Action<MessagePipeOptions, ContainerBuilder> use)
     {
         var builder = new ContainerBuilder();

--- a/src/MessagePipe.Unity/Assets/Tests/VContainerTest.cs
+++ b/src/MessagePipe.Unity/Assets/Tests/VContainerTest.cs
@@ -13,10 +13,7 @@ public class VContainerTest
     [Test]
     public void SimpelePush()
     {
-        var resolver = TestHelper.BuildVContainer((options, builder) =>
-       {
-           builder.RegisterMessageBroker<int>(options);
-       });
+        var resolver = TestHelper.BuildVContainer();
 
         var pub = resolver.Resolve<IPublisher<int>>();
         var sub1 = resolver.Resolve<ISubscriber<int>>();
@@ -40,10 +37,7 @@ public class VContainerTest
     [UnityTest]
     public IEnumerator SimpleAsyncPush() => UniTask.ToCoroutine(async () =>
     {
-        var resolver = TestHelper.BuildVContainer((options, builder) =>
-       {
-           builder.RegisterMessageBroker<int>(options);
-       });
+        var resolver = TestHelper.BuildVContainer();
 
         var pub = resolver.Resolve<IAsyncPublisher<int>>();
         var sub1 = resolver.Resolve<IAsyncSubscriber<int>>();
@@ -74,8 +68,6 @@ public class VContainerTest
            options.AddGlobalMessageHandlerFilter<MyFilter<int>>(1200);
        }, (options, builder) =>
        {
-           builder.RegisterMessageBroker<int>(options);
-
            builder.RegisterMessageHandlerFilter<MyFilter<int>>();
            builder.RegisterInstance(store);
        });
@@ -160,10 +152,7 @@ public class VContainerTest
     [Test]
     public void Buffered()
     {
-        var provider = TestHelper.BuildVContainer((options, builder) =>
-        {
-            builder.RegisterMessageBroker<IntClass>(options);
-        });
+        var provider = TestHelper.BuildVContainer();
 
         var p = provider.Resolve<IBufferedPublisher<IntClass>>();
         var s = provider.Resolve<IBufferedSubscriber<IntClass>>();

--- a/src/MessagePipe.Unity/Assets/Tests/VContainerTest.cs
+++ b/src/MessagePipe.Unity/Assets/Tests/VContainerTest.cs
@@ -13,7 +13,12 @@ public class VContainerTest
     [Test]
     public void SimpelePush()
     {
-        var resolver = TestHelper.BuildVContainer();
+        var resolver = TestHelper.BuildVContainer((options, builder) =>
+        {
+#if !UNITY_2022_1_OR_NEWER            
+            builder.RegisterMessageBroker<int>(options);
+#endif
+        });            
 
         var pub = resolver.Resolve<IPublisher<int>>();
         var sub1 = resolver.Resolve<ISubscriber<int>>();
@@ -37,7 +42,12 @@ public class VContainerTest
     [UnityTest]
     public IEnumerator SimpleAsyncPush() => UniTask.ToCoroutine(async () =>
     {
-        var resolver = TestHelper.BuildVContainer();
+        var resolver = TestHelper.BuildVContainer((options, builder) =>
+        {
+#if !UNITY_2022_1_OR_NEWER            
+            builder.RegisterMessageBroker<int>(options);
+#endif
+        });        
 
         var pub = resolver.Resolve<IAsyncPublisher<int>>();
         var sub1 = resolver.Resolve<IAsyncSubscriber<int>>();
@@ -68,6 +78,10 @@ public class VContainerTest
            options.AddGlobalMessageHandlerFilter<MyFilter<int>>(1200);
        }, (options, builder) =>
        {
+#if !UNITY_2022_1_OR_NEWER           
+           builder.RegisterMessageBroker<int>(options);
+#endif
+           
            builder.RegisterMessageHandlerFilter<MyFilter<int>>();
            builder.RegisterInstance(store);
        });
@@ -152,7 +166,12 @@ public class VContainerTest
     [Test]
     public void Buffered()
     {
-        var provider = TestHelper.BuildVContainer();
+        var provider = TestHelper.BuildVContainer((options, builder) =>
+        {
+#if !UNITY_2022_1_OR_NEWER            
+            builder.RegisterMessageBroker<IntClass>(options);
+#endif
+        });        
 
         var p = provider.Resolve<IBufferedPublisher<IntClass>>();
         var s = provider.Resolve<IBufferedSubscriber<IntClass>>();

--- a/src/MessagePipe.Unity/Packages/manifest.json
+++ b/src/MessagePipe.Unity/Packages/manifest.json
@@ -7,6 +7,6 @@
     "com.unity.test-framework": "1.1.24",
     "com.unity.toolchain.win-x86_64-linux-x86_64": "0.1.20-preview",
     "com.unity.ugui": "1.0.0",
-    "jp.hadashikick.vcontainer": "https://github.com/hadashiA/VContainer.git?path=VContainer/Assets/VContainer"
+    "jp.hadashikick.vcontainer": "https://github.com/hadashiA/VContainer.git?path=VContainer/Assets/VContainer#1.15.2"
   }
 }

--- a/src/MessagePipe.Unity/Packages/packages-lock.json
+++ b/src/MessagePipe.Unity/Packages/packages-lock.json
@@ -39,13 +39,6 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
-    "com.unity.nuget.mono-cecil": {
-      "version": "1.10.1",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
     "com.unity.sysroot": {
       "version": "0.1.19-preview",
       "depth": 1,
@@ -93,13 +86,11 @@
       }
     },
     "jp.hadashikick.vcontainer": {
-      "version": "https://github.com/hadashiA/VContainer.git?path=VContainer/Assets/VContainer",
+      "version": "https://github.com/hadashiA/VContainer.git?path=VContainer/Assets/VContainer#1.15.2",
       "depth": 0,
       "source": "git",
-      "dependencies": {
-        "com.unity.nuget.mono-cecil": "1.10.1"
-      },
-      "hash": "04c22dc81b4c8b0ccfc133050f23a08b9fc0934e"
+      "dependencies": {},
+      "hash": "634d03aa8349e5698be39d487e2ef0f9d5c881d9"
     },
     "com.unity.modules.imgui": {
       "version": "1.0.0",

--- a/src/MessagePipe/ServiceCollectionExtensions.cs
+++ b/src/MessagePipe/ServiceCollectionExtensions.cs
@@ -40,7 +40,7 @@ namespace MessagePipe
                 services.TryAddTransient(item); // filter itself is Transient
             }
 
-#if !UNITY_2018_3_OR_NEWER || MESSAGEPIPE_OPENGENERICS_SUPPORT
+#if !UNITY_2018_3_OR_NEWER || (MESSAGEPIPE_OPENGENERICS_SUPPORT && UNITY_2022_1_OR_NEWER)
             // open generics implemntations(.NET Only)
 
             {

--- a/src/MessagePipe/ServiceCollectionExtensions.cs
+++ b/src/MessagePipe/ServiceCollectionExtensions.cs
@@ -40,7 +40,7 @@ namespace MessagePipe
                 services.TryAddTransient(item); // filter itself is Transient
             }
 
-#if !UNITY_2018_3_OR_NEWER
+#if !UNITY_2018_3_OR_NEWER || MESSAGEPIPE_OPENGENERICS_SUPPORT
             // open generics implemntations(.NET Only)
 
             {
@@ -107,6 +107,8 @@ namespace MessagePipe
 
             var lifetime2 = options.RequestHandlerLifetime; // requesthandler lifetime
 
+#endif
+#if !UNITY_2018_3_OR_NEWER
             // RequestHandler
             services.Add(typeof(IRequestHandler<,>), typeof(RequestHandler<,>), lifetime2);
             services.Add(typeof(IAsyncRequestHandler<,>), typeof(AsyncRequestHandler<,>), lifetime2);
@@ -114,7 +116,7 @@ namespace MessagePipe
             // RequestAll
             services.Add(typeof(IRequestAllHandler<,>), typeof(RequestAllHandler<,>), lifetime2);
             services.Add(typeof(IAsyncRequestAllHandler<,>), typeof(AsyncRequestAllHandler<,>), lifetime2);
-
+            
             // auto registration is .NET only.
             if (options.EnableAutoRegistration)
             {


### PR DESCRIPTION
#119 

If you use Container 1.14 or later, support for automatic resolution by open generics.

NOTE:
RequestHandler is still not supported. This is because assembly scanning is required.