### PR TITLE
ci: change upload-artifact & download-artifact to Cysharp/Actions

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -38,7 +38,7 @@ jobs:
       - run: dotnet build -c Debug
       - run: dotnet test -c Debug --no-build
       # Store artifacts.
-      - uses: actions/upload-artifact@v2
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: MessagePipe.Analyzer
           path: ./src/MessagePipe.Analyzer/bin/Debug/netstandard2.0/MessagePipe.Analyzer.dll
@@ -100,7 +100,7 @@ jobs:
           directory: src/MessagePipe.Unity
 
       # Store artifacts.
-      - uses: actions/upload-artifact@v2
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: MessagePipe.${{ matrix.unity }}.unitypackage.zip
           path: ./src/MessagePipe.Unity/*.unitypackage

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           name: MessagePipe.Analyzer
           path: ./src/MessagePipe.Analyzer/bin/Debug/netstandard2.0/MessagePipe.Analyzer.dll
+          retention-days: 1
 
   build-unity:
     if: ${{ (github.event_name == 'push' && github.repository_owner == 'Cysharp') || startsWith(github.event.pull_request.head.label, 'Cysharp:') }}
@@ -104,3 +105,4 @@ jobs:
         with:
           name: MessagePipe.${{ matrix.unity }}.unitypackage.zip
           path: ./src/MessagePipe.Unity/*.unitypackage
+          retention-days: 1

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -64,11 +64,13 @@ jobs:
           name: nuget
           path: ./publish/
           if-no-files-found: error
+          retention-days: 1
       # Upload analyzer.
       - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: MessagePipe.Analyzer
           path: ./src/MessagePipe.Analyzer/bin/Release/netstandard2.0/MessagePipe.Analyzer.dll
+          retention-days: 1
 
   build-unity:
     needs: [update-packagejson]
@@ -117,6 +119,7 @@ jobs:
           name: MessagePipe.Unity.${{ inputs.tag }}.unitypackage
           path: ./src/MessagePipe.Unity/MessagePipe*.${{ inputs.tag }}.unitypackage
           if-no-files-found: error
+          retention-days: 1
 
   # release
   create-release:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -59,13 +59,13 @@ jobs:
       - run: dotnet test -c Release --no-build
       - run: dotnet pack -c Release --no-build -p:Version=${{ inputs.tag }} -o ./publish
       # Store artifacts.
-      - uses: actions/upload-artifact@v2
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: nuget
           path: ./publish/
           if-no-files-found: error
       # Upload analyzer.
-      - uses: actions/upload-artifact@v2
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: MessagePipe.Analyzer
           path: ./src/MessagePipe.Analyzer/bin/Release/netstandard2.0/MessagePipe.Analyzer.dll
@@ -112,7 +112,7 @@ jobs:
           directory: src/MessagePipe.Unity
 
       # Store artifacts.
-      - uses: actions/upload-artifact@v2
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: MessagePipe.Unity.${{ inputs.tag }}.unitypackage
           path: ./src/MessagePipe.Unity/MessagePipe*.${{ inputs.tag }}.unitypackage


### PR DESCRIPTION
## tl;dr;

To handle actions/upload-artifact & download-artifact version consistency, manage actions version via Central Maanged Cysharp/Actions.
